### PR TITLE
Fix panic when /tmp does not exist in Docker

### DIFF
--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -42,8 +42,12 @@ func RunServer(flags *Flags) {
 	}
 
 	if flags.Data == "" {
+		// Ensure the system temp directory exists — minimal Docker images
+		// (e.g. scratch, distroless) may not include /tmp.
+		if err := os.MkdirAll(os.TempDir(), 0755); err != nil {
+			panic(err)
+		}
 		dir, err := os.MkdirTemp("", "scanii-cli")
-
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Summary
- Ensure the system temp directory exists before calling `os.MkdirTemp`, preventing a panic in minimal Docker images (scratch, distroless) that don't include `/tmp`

Fixes #26

## Test plan
- [ ] Build and run in a minimal Docker image without `/tmp` — server should start without panic
- [ ] Verify `make audit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)