### PR TITLE
feat: add `sc files trace` command for the trace endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `scanii-cli` are documented here. Versions follow [SemVer](https://semver.org).
 
-## Unreleased
+## v1.5.0 — 2026-05-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,20 @@
 # Changelog
 
-All notable changes to `scanii-cli` are documented here. Versions follow [SemVer](https://semver.org).
-
-## v1.5.0 — 2026-05-02
+## [1.5.0]
 
 ### Added
 
 - `sc files trace <id>` command — wraps the `GET /v2.2/files/{id}/trace` endpoint and prints the events as a `timestamp / message` table.
 - `Client.RetrieveTrace(ctx, id)` in `internal/client`.
 
-## v1.4.0 — 2026-05-01
+## [1.4.0]
 
 ### Added
 
 - `GET /v2.2/files/{id}/trace` mock-server endpoint.
 - `location` field support for `POST /v2.2/files`.
 
-## v1.3.1 — 2026-04-30
+## [1.3.1]
 
 ### Added
 
@@ -26,13 +24,13 @@ All notable changes to `scanii-cli` are documented here. Versions follow [SemVer
 
 - Improved terminal output formatting and warning labels.
 
-## v1.3.0 — 2026-04-24
+## [1.3.0]
 
 ### Changed
 
 - Docker image improvements.
 
-## v1.2.0 — 2026-04-24
+## [1.2.0]
 
 ### Removed
 
@@ -42,13 +40,13 @@ All notable changes to `scanii-cli` are documented here. Versions follow [SemVer
 
 - Docker image namespace updated in the Goreleaser config.
 
-## v1.1.1 — 2026-04-24
+## [1.1.1]
 
 ### Changed
 
 - Expanded README with usage examples and a CI guide.
 
-## v1.1.0 — 2026-04-24
+## [1.1.0]
 
 ### Added
 
@@ -59,7 +57,7 @@ All notable changes to `scanii-cli` are documented here. Versions follow [SemVer
 
 - Panic when `/tmp` does not exist inside the Docker container.
 
-## v1.0.0 — 2026-04-23
+## [1.0.0]
 
 First stable release published under the `scanii/scanii-cli` repo.
 
@@ -67,6 +65,6 @@ First stable release published under the `scanii/scanii-cli` repo.
 
 - Multiple profile support — named profiles via `sc profile create [name]` and `-p, --profile` global flag.
 
-## v0.1.x and earlier
+## [0.1.x and earlier]
 
 Pre-1.0 releases lived under `uvasoftware/scanii-cli`. See the [GitHub releases page](https://github.com/scanii/scanii-cli/releases?q=v0.) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to `scanii-cli` are documented here. Versions follow [SemVer](https://semver.org).
+
+## Unreleased
+
+### Added
+
+- `sc files trace <id>` command — wraps the `GET /v2.2/files/{id}/trace` endpoint and prints the events as a `timestamp / message` table.
+- `Client.RetrieveTrace(ctx, id)` in `internal/client`.
+
+## v1.4.0 — 2026-05-01
+
+### Added
+
+- `GET /v2.2/files/{id}/trace` mock-server endpoint.
+- `location` field support for `POST /v2.2/files`.
+
+## v1.3.1 — 2026-04-30
+
+### Added
+
+- `/healthcheck` route used by the Docker container health check.
+
+### Changed
+
+- Improved terminal output formatting and warning labels.
+
+## v1.3.0 — 2026-04-24
+
+### Changed
+
+- Docker image improvements.
+
+## v1.2.0 — 2026-04-24
+
+### Removed
+
+- Dependabot config.
+
+### Changed
+
+- Docker image namespace updated in the Goreleaser config.
+
+## v1.1.1 — 2026-04-24
+
+### Changed
+
+- Expanded README with usage examples and a CI guide.
+
+## v1.1.0 — 2026-04-24
+
+### Added
+
+- Callback delivery support in the local server.
+- Embedded test asset fixtures.
+
+### Fixed
+
+- Panic when `/tmp` does not exist inside the Docker container.
+
+## v1.0.0 — 2026-04-23
+
+First stable release published under the `scanii/scanii-cli` repo.
+
+### Added
+
+- Multiple profile support — named profiles via `sc profile create [name]` and `-p, --profile` global flag.
+
+## v0.1.x and earlier
+
+Pre-1.0 releases lived under `uvasoftware/scanii-cli`. See the [GitHub releases page](https://github.com/scanii/scanii-cli/releases?q=v0.) for details.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Retrieve the result of an async scan:
 sc files retrieve RESULT_ID
 ```
 
+Retrieve the processing trace for a result:
+
+```shell
+sc files trace RESULT_ID
+```
+
 ### 4. Scan a remote URL
 
 Submit a URL for server-side fetch and scan:
@@ -208,6 +214,7 @@ All endpoints are under the `/v2.2/` prefix and require HTTP Basic Auth:
 | `POST` | `/v2.2/files/async` | Async file scan (returns pending ID) |
 | `POST` | `/v2.2/files/fetch` | Fetch remote URL and scan |
 | `GET` | `/v2.2/files/{id}` | Retrieve scan result |
+| `GET` | `/v2.2/files/{id}/trace` | Retrieve processing trace |
 | `POST` | `/v2.2/auth/tokens` | Create auth token |
 | `GET` | `/v2.2/auth/tokens/{id}` | Retrieve auth token |
 | `DELETE` | `/v2.2/auth/tokens/{id}` | Delete auth token |
@@ -483,6 +490,7 @@ When using the local server (Docker or binary), the default credentials are:
 | `sc files async <path>` | Asynchronous file/directory scan |
 | `sc files fetch <url>` | Fetch and scan a remote URL |
 | `sc files retrieve <id>` | Retrieve a scan result |
+| `sc files trace <id>` | Retrieve the processing trace for a scan result |
 | `sc auth-token create` | Create a temporary auth token |
 | `sc auth-token retrieve <id>` | Retrieve token details |
 | `sc auth-token delete <id>` | Revoke a token |

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -98,6 +98,13 @@ type RetrieveFileResult struct {
 	Result *ProcessingResponse
 }
 
+// RetrieveTraceResult is the response from the trace retrieve endpoint.
+type RetrieveTraceResult struct {
+	Response
+	Trace *TraceResponse
+	Error *ErrorResponse
+}
+
 // CreateTokenResult is the response from the create token endpoint.
 type CreateTokenResult struct {
 	Response
@@ -255,6 +262,31 @@ func (c *Client) RetrieveFile(ctx context.Context, id string) (*RetrieveFileResu
 			return nil, fmt.Errorf("parsing retrieve file response: %w", err)
 		}
 		result.Result = &pr
+	}
+	return result, nil
+}
+
+// RetrieveTrace retrieves the processing trace for a previously processed file.
+func (c *Client) RetrieveTrace(ctx context.Context, id string) (*RetrieveTraceResult, error) {
+	status, header, body, err := c.do(ctx, http.MethodGet, "/files/"+id+"/trace", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	result := &RetrieveTraceResult{Response: Response{StatusCode: status, Header: header}}
+	if len(body) > 0 {
+		switch {
+		case status == http.StatusOK:
+			var tr TraceResponse
+			if err := json.Unmarshal(body, &tr); err != nil {
+				return nil, fmt.Errorf("parsing retrieve trace response: %w", err)
+			}
+			result.Trace = &tr
+		case status >= 400:
+			var er ErrorResponse
+			if err := json.Unmarshal(body, &er); err == nil {
+				result.Error = &er
+			}
+		}
 	}
 	return result, nil
 }

--- a/internal/commands/file/command.go
+++ b/internal/commands/file/command.go
@@ -22,6 +22,7 @@ func Command(ctx context.Context, profile *string) *cobra.Command {
 	parent.AddCommand(asyncCommand(ctx, profile, &metadata))
 	parent.AddCommand(fetchCommand(ctx, profile, &metadata))
 	parent.AddCommand(retrieveCommand(ctx, profile))
+	parent.AddCommand(traceCommand(ctx, profile))
 
 	return &parent
 }

--- a/internal/commands/file/trace.go
+++ b/internal/commands/file/trace.go
@@ -1,0 +1,110 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/spf13/cobra"
+	"github.com/uvasoftware/scanii-cli/internal/client"
+	profile2 "github.com/uvasoftware/scanii-cli/internal/commands/profile"
+	"github.com/uvasoftware/scanii-cli/internal/terminal"
+)
+
+func traceCommand(ctx context.Context, profileName *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:        "trace [flags] [id]",
+		Short:      "Retrieve the processing trace for a previously created processing result",
+		Args:       cobra.ExactArgs(1),
+		ArgAliases: []string{"id"},
+		RunE: func(_ *cobra.Command, args []string) error {
+
+			profile, err := profile2.Load(*profileName)
+			if err != nil {
+				return err
+			}
+			c, err := profile.Client()
+			if err != nil {
+				return err
+			}
+
+			_, err = callFileTrace(ctx, c, args[0])
+			return err
+		},
+	}
+
+	return cmd
+}
+
+type traceRecord struct {
+	id     string
+	events []traceEventRecord
+}
+
+type traceEventRecord struct {
+	timestamp string
+	message   string
+}
+
+func callFileTrace(ctx context.Context, c *client.Client, id string) (*traceRecord, error) {
+	if id == "" {
+		return nil, errors.New("id cannot be empty")
+	}
+
+	slog.Debug("retrieving trace", "id", id)
+
+	resp, err := c.RetrieveTrace(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("no trace exists for processing id %s", id)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.Error != nil && resp.Error.Error != nil {
+			return nil, fmt.Errorf("error retrieving trace for id %s: %s", id, *resp.Error.Error)
+		}
+		return nil, fmt.Errorf("error retrieving trace for id %s, status code %d", id, resp.StatusCode)
+	}
+
+	tr := resp.Trace
+	record := traceRecord{id: id}
+	if tr != nil && tr.ID != nil {
+		record.id = *tr.ID
+	}
+	if tr != nil && tr.Events != nil {
+		for _, e := range *tr.Events {
+			ev := traceEventRecord{}
+			if e.Timestamp != nil {
+				ev.timestamp = *e.Timestamp
+			}
+			if e.Message != nil {
+				ev.message = *e.Message
+			}
+			record.events = append(record.events, ev)
+		}
+	}
+
+	printTraceResult(&record)
+	return &record, nil
+}
+
+func printTraceResult(r *traceRecord) {
+	terminal.KeyValue("id:", r.id)
+
+	if len(r.events) == 0 {
+		terminal.KeyValue("events:", "none")
+		return
+	}
+
+	rows := make([][]string, 0, len(r.events))
+	for _, e := range r.events {
+		rows = append(rows, []string{terminal.FormatTime(e.timestamp), e.message})
+	}
+	fmt.Println("  events:")
+	terminal.Table([]string{"timestamp", "message"}, rows)
+}

--- a/internal/commands/file/trace_test.go
+++ b/internal/commands/file/trace_test.go
@@ -1,0 +1,75 @@
+package file
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCallFileTraceEmptyID(t *testing.T) {
+	c, err := ts.Profile.Client()
+	if err != nil {
+		t.Fatalf("failed to create client: %s", err)
+	}
+
+	_, err = callFileTrace(context.Background(), c, "")
+	if err == nil {
+		t.Fatalf("expected error for empty id")
+	}
+}
+
+func TestCallFileTraceUnknownID(t *testing.T) {
+	c, err := ts.Profile.Client()
+	if err != nil {
+		t.Fatalf("failed to create client: %s", err)
+	}
+
+	_, err = callFileTrace(context.Background(), c, "doesnotexist")
+	if err == nil {
+		t.Fatalf("expected error for unknown id")
+	}
+	if !strings.Contains(err.Error(), "doesnotexist") {
+		t.Fatalf("expected error to mention id, got %s", err)
+	}
+}
+
+func TestCallFileTraceKnownID(t *testing.T) {
+	c, err := ts.Profile.Client()
+	if err != nil {
+		t.Fatalf("failed to create client: %s", err)
+	}
+
+	// process a file first to get an id
+	processed, err := runLocationProcess(
+		context.Background(),
+		c,
+		"http://"+ts.Endpoint+"/static/eicar.txt",
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("failed to process file: %s", err)
+	}
+	if processed.id == "" {
+		t.Fatalf("expected processed result to have an id")
+	}
+
+	trace, err := callFileTrace(context.Background(), c, processed.id)
+	if err != nil {
+		t.Fatalf("failed to retrieve trace: %s", err)
+	}
+	if trace.id != processed.id {
+		t.Fatalf("expected trace id %s, got %s", processed.id, trace.id)
+	}
+	if len(trace.events) < 2 {
+		t.Fatalf("expected at least 2 trace events, got %d", len(trace.events))
+	}
+	for i, ev := range trace.events {
+		if ev.timestamp == "" {
+			t.Errorf("event[%d]: empty timestamp", i)
+		}
+		if ev.message == "" {
+			t.Errorf("event[%d]: empty message", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `sc files trace <id>` command, which wraps the `GET /v2.2/files/{id}/trace` endpoint shipped server-side in #79.
- Adds `Client.RetrieveTrace(ctx, id)` to `internal/client` (parses `TraceResponse` on 200, `ErrorResponse` on 4xx).
- Prints trace events as a two-column `timestamp / message` table; empty/unknown ids surface as explicit errors.
- README updated with the new command in the quickstart, the all-commands table, and the local-server endpoint table.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] New tests in `internal/commands/file/trace_test.go` cover empty id, unknown id, and a positive round-trip (process → trace) — all pass against the in-process mock server
- [ ] Manual: `sc files trace <id>` against a `sc server` instance renders timestamps + messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)