### PR TITLE
feat: serve CORS headers for browser-based clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.0]
+
+### Added
+
+- CORS support on the mock server, matching `api.scanii.com` in production (`Allow-Origin: *`, `Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE`, `Allow-Headers: Authorization, User-Agent`, `Max-Age: 300`). OPTIONS preflight short-circuits with 200, no credentials required. Lets browser-based clients call the mock from a different origin.
+
 ## [1.5.0]
 
 ### Added

--- a/internal/commands/server/callback_test.go
+++ b/internal/commands/server/callback_test.go
@@ -95,7 +95,7 @@ func startServer(t *testing.T) *httptest.Server {
 		t.Fatalf("engine.New: %s", err)
 	}
 	mux := http.NewServeMux()
-	ts := httptest.NewUnstartedServer(mux)
+	ts := httptest.NewUnstartedServer(CORS(mux))
 	// Setup needs the externally visible base URL for Location headers;
 	// we pass it after the listener is bound.
 	ts.Start()

--- a/internal/commands/server/cors_test.go
+++ b/internal/commands/server/cors_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestCORS_PreflightReturnsAllowHeaders verifies that an OPTIONS preflight
+// against an authenticated route succeeds without credentials and returns
+// the Access-Control headers a browser needs to permit the follow-up call.
+func TestCORS_PreflightReturnsAllowHeaders(t *testing.T) {
+	ts := startServer(t)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, ts.URL+"/v2.2/files", http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %s", err)
+	}
+	req.Header.Set("Origin", "http://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "authorization")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("preflight: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("preflight status: want 200, got %d", resp.StatusCode)
+	}
+
+	checks := map[string]string{
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "GET, POST, HEAD, OPTIONS, DELETE",
+		"Access-Control-Allow-Headers": "Authorization, User-Agent",
+		"Access-Control-Max-Age":       "300",
+	}
+	for header, want := range checks {
+		if got := resp.Header.Get(header); got != want {
+			t.Errorf("%s: want %q, got %q", header, want, got)
+		}
+	}
+}
+
+// TestCORS_AllowOriginOnAuthenticatedResponse verifies that the Allow-Origin
+// header is also present on the actual cross-origin request (not just the
+// preflight) so the browser will let the calling script read the response.
+func TestCORS_AllowOriginOnAuthenticatedResponse(t *testing.T) {
+	ts := startServer(t)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/v2.2/ping", http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %s", err)
+	}
+	req.SetBasicAuth("key", "secret")
+	req.Header.Set("Origin", "http://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ping status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin: want %q, got %q", "*", got)
+	}
+}

--- a/internal/commands/server/routes.go
+++ b/internal/commands/server/routes.go
@@ -30,6 +30,24 @@ func middleware(h http.Handler, mws ...func(http.Handler) http.Handler) http.Han
 	return h
 }
 
+// CORS wraps a handler so browser-based clients can call the mock from a
+// different origin. The header set mirrors what the real Scanii API serves
+// in production. OPTIONS preflight requests are answered with 200 + the
+// Access-Control headers and do not reach the wrapped handler.
+func CORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, HEAD, OPTIONS, DELETE")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, User-Agent")
+		w.Header().Set("Access-Control-Max-Age", "300")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func Setup(mux *http.ServeMux, eng *engine.Engine, key, secret, data, baseURL string) {
 	handlers := FakeHandler{
 		engine:  eng,

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -79,7 +79,7 @@ func RunServer(flags *Flags) {
 		MessageFieldName: "message",
 		TimeFieldFormat:  time.DateTime,
 	})
-	handler := httplog.RequestLogger(logger)(mux)
+	handler := CORS(httplog.RequestLogger(logger)(mux))
 
 	srv := &http.Server{
 		Addr:         flags.Address,


### PR DESCRIPTION
## Summary

- Adds a CORS middleware (`server.CORS`) that wraps the mock server's handler chain. Headers mirror what `api.scanii.com` serves in production: `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE`, `Access-Control-Allow-Headers: Authorization, User-Agent`, `Access-Control-Max-Age: 300`.
- OPTIONS preflight short-circuits with 200 + the Allow-* headers (no auth required, matching production); all other methods gain `Access-Control-Allow-Origin: *` on the response so the browser permits the calling script to read it.
- Wired into `RunServer` and the `startServer` test helper so every existing test now runs through the CORS layer too.

## Motivation

Without this, browsers cannot call the mock from a different origin — `OPTIONS /v2.2/files` returned 405 with no Access-Control headers. That makes scanii-cli unusable for validating any of the browser-side flows the real API supports, including the [client-side arbitration sample](https://github.com/scanii/scanii-token-sample) where the browser uploads files directly to Scanii using a short-lived auth token.

## Test plan

- [x] New `cors_test.go` covers OPTIONS preflight (200 + Allow-* headers, no credentials) and Allow-Origin on authenticated GET responses.
- [x] `go test ./...` — all packages pass.
- [x] Locally built `sc server -a 0.0.0.0:4000` returns expected headers for OPTIONS preflight against `/v2.2/files`.