### PR TITLE
feat: Homebrew tap + shell installer for easier install

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -31,3 +31,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 
 builds:
   - env:
@@ -7,6 +7,12 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     main: ./cmd/sc/main.go
     binary: sc
     ldflags: -s -w -X main.version={{.Version}} -X main.date={{.Date}}
@@ -18,15 +24,32 @@ dockers:
       - "ghcr.io/scanii/scanii-cli:latest"
 report_sizes: true
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - LICENSE
       - README.md
+
+checksum:
+  name_template: checksums.txt
+
+brews:
+  - name: scanii-cli
+    repository:
+      owner: scanii
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://www.scanii.com
+    description: "Scanii CLI — interact with the Scanii API and run a local mock server for integration testing"
+    license: Apache-2.0
+    install: |
+      bin.install "sc"
+    test: |
+      system "#{bin}/sc", "version"
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,9 +10,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
     main: ./cmd/sc/main.go
     binary: sc
     ldflags: -s -w -X main.version={{.Version}} -X main.date={{.Date}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- `.goreleaser.yaml` now pins the build matrix explicitly to `amd64`+`arm64` (Windows stays `amd64`-only), so the shell installer can rely on a stable archive-name contract.
+- `.goreleaser.yaml` now pins the build matrix explicitly to `amd64`+`arm64` across all OSes, so the shell installer can rely on a stable archive-name contract. The `386` archives (linux-386, windows-386) are no longer produced — no GitHub-hosted runner uses them and they had no known consumers.
 
 ## [1.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.7.0]
+
+### Added
+
+- Homebrew install path. Goreleaser now publishes the formula to `scanii/homebrew-tap` on every release: `brew install scanii/tap/scanii-cli`.
+- Shell installer at `install.sh`. POSIX-compatible script that detects OS/arch, fetches the matching release archive, verifies the SHA-256, and installs `sc` to `~/.local/bin` (override via `SCANII_CLI_BIN_DIR`, pin a version via `SCANII_CLI_VERSION`): `curl -fsSL https://raw.githubusercontent.com/scanii/scanii-cli/main/install.sh | sh`.
+
+### Changed
+
+- `.goreleaser.yaml` now pins the build matrix explicitly to `amd64`+`arm64` (Windows stays `amd64`-only), so the shell installer can rely on a stable archive-name contract.
+
 ## [1.6.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,15 +10,19 @@ The Scanii CLI (`sc`) helps you build, test, and manage your [Scanii](https://ww
 
 ## Installation
 
-### Binary releases
-
-Pre-built binaries for macOS, Windows, and Linux are available on the [releases page](https://github.com/scanii/scanii-cli/releases).
-
-On macOS, you may need to remove the quarantine attribute before running:
+### Homebrew (macOS, Linux)
 
 ```shell
-xattr -d com.apple.quarantine /path/to/sc
+brew install scanii/tap/scanii-cli
 ```
+
+### Shell installer (macOS, Linux)
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/scanii/scanii-cli/main/install.sh | sh
+```
+
+The installer downloads the matching release archive from GitHub, verifies it against `checksums.txt`, and installs `sc` to `~/.local/bin` (override with `SCANII_CLI_BIN_DIR`). Pin a specific version with `SCANII_CLI_VERSION=1.6.0`.
 
 ### Docker
 
@@ -29,6 +33,16 @@ docker run ghcr.io/scanii/scanii-cli:latest
 ```
 
 Previous versions are listed [here](https://github.com/scanii/scanii-cli/pkgs/container/scanii-cli).
+
+### Binary releases
+
+Pre-built binaries for macOS, Windows, and Linux are available on the [releases page](https://github.com/scanii/scanii-cli/releases).
+
+On macOS, you may need to remove the quarantine attribute before running:
+
+```shell
+xattr -d com.apple.quarantine /path/to/sc
+```
 
 ## Quick start
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+#
+# Scanii CLI installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/scanii/scanii-cli/main/install.sh | sh
+#
+# Environment overrides:
+#   SCANII_CLI_VERSION    Version to install (e.g. "1.6.0"). Defaults to the latest release.
+#   SCANII_CLI_BIN_DIR    Directory to install `sc` into. Defaults to "$HOME/.local/bin".
+#
+set -eu
+
+REPO="scanii/scanii-cli"
+BIN_NAME="sc"
+BIN_DIR="${SCANII_CLI_BIN_DIR:-$HOME/.local/bin}"
+REQUESTED_VERSION="${SCANII_CLI_VERSION:-latest}"
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || err "required command not found: $1"
+}
+
+need uname
+need tar
+need mkdir
+need mv
+need rm
+
+# Prefer curl, fall back to wget.
+if command -v curl >/dev/null 2>&1; then
+  DL="curl"
+elif command -v wget >/dev/null 2>&1; then
+  DL="wget"
+else
+  err "need either curl or wget to download release artifacts"
+fi
+
+# OS detection.
+case "$(uname -s)" in
+  Darwin) OS="darwin" ;;
+  Linux)  OS="linux" ;;
+  *)
+    err "unsupported OS: $(uname -s). Download a binary from https://github.com/${REPO}/releases instead."
+    ;;
+esac
+
+# Arch detection.
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *)
+    err "unsupported arch: $(uname -m). Download a binary from https://github.com/${REPO}/releases instead."
+    ;;
+esac
+
+# Checksum tool.
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA_TOOL="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA_TOOL="shasum -a 256"
+else
+  err "need either sha256sum or shasum to verify the download"
+fi
+
+fetch() {
+  # fetch <url> <output-path>
+  if [ "$DL" = "curl" ]; then
+    curl -fsSL --retry 3 -o "$2" "$1"
+  else
+    wget -q -O "$2" "$1"
+  fi
+}
+
+# Resolve "latest" to a concrete version by following the GitHub redirect.
+# /releases/latest redirects to /releases/tag/v<version>.
+resolve_latest() {
+  url="https://github.com/${REPO}/releases/latest"
+  if [ "$DL" = "curl" ]; then
+    location=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$url")
+  else
+    # wget prints the redirect chain on stderr with --max-redirect=0.
+    location=$(wget -q --max-redirect=0 --server-response "$url" 2>&1 | awk '/^  Location:/ {print $2}' | tail -n 1)
+  fi
+  # location looks like https://github.com/scanii/scanii-cli/releases/tag/v1.6.0
+  version=${location##*/tag/}
+  # strip leading v if present
+  case "$version" in
+    v*) version=${version#v} ;;
+  esac
+  if [ -z "$version" ] || [ "$version" = "$location" ]; then
+    err "could not determine the latest release version from $url"
+  fi
+  printf '%s' "$version"
+}
+
+if [ "$REQUESTED_VERSION" = "latest" ]; then
+  VERSION=$(resolve_latest)
+else
+  # Allow callers to pass "v1.6.0" or "1.6.0" interchangeably.
+  case "$REQUESTED_VERSION" in
+    v*) VERSION=${REQUESTED_VERSION#v} ;;
+    *)  VERSION=$REQUESTED_VERSION ;;
+  esac
+fi
+
+ARCHIVE="scanii-cli-${VERSION}-${OS}-${ARCH}.tar.gz"
+BASE_URL="https://github.com/${REPO}/releases/download/v${VERSION}"
+ARCHIVE_URL="${BASE_URL}/${ARCHIVE}"
+CHECKSUMS_URL="${BASE_URL}/checksums.txt"
+
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t scanii-cli)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+log "Installing scanii-cli ${VERSION} for ${OS}/${ARCH}"
+log "  source: ${ARCHIVE_URL}"
+
+fetch "$ARCHIVE_URL"   "${TMP_DIR}/${ARCHIVE}"
+fetch "$CHECKSUMS_URL" "${TMP_DIR}/checksums.txt"
+
+# Verify checksum.
+(
+  cd "$TMP_DIR"
+  expected=$(awk -v a="$ARCHIVE" '$2 == a {print $1}' checksums.txt)
+  if [ -z "$expected" ]; then
+    err "checksum for $ARCHIVE not found in checksums.txt"
+  fi
+  actual=$($SHA_TOOL "$ARCHIVE" | awk '{print $1}')
+  if [ "$expected" != "$actual" ]; then
+    err "checksum mismatch for $ARCHIVE (expected $expected, got $actual)"
+  fi
+)
+
+# Extract. Archive wraps contents in a top-level directory.
+tar -xzf "${TMP_DIR}/${ARCHIVE}" -C "$TMP_DIR"
+
+EXTRACTED_BIN="${TMP_DIR}/scanii-cli-${VERSION}-${OS}-${ARCH}/${BIN_NAME}"
+if [ ! -f "$EXTRACTED_BIN" ]; then
+  err "expected binary not found in archive at $EXTRACTED_BIN"
+fi
+
+mkdir -p "$BIN_DIR"
+mv "$EXTRACTED_BIN" "${BIN_DIR}/${BIN_NAME}"
+chmod +x "${BIN_DIR}/${BIN_NAME}"
+
+# Best-effort: clear the macOS quarantine attribute set by Gatekeeper.
+if [ "$OS" = "darwin" ] && command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "${BIN_DIR}/${BIN_NAME}" 2>/dev/null || true
+fi
+
+log ""
+log "Installed ${BIN_NAME} to ${BIN_DIR}/${BIN_NAME}"
+
+case ":${PATH}:" in
+  *":${BIN_DIR}:"*)
+    log "Run '${BIN_NAME} --help' to get started."
+    ;;
+  *)
+    log "Add ${BIN_DIR} to your PATH to run '${BIN_NAME}' from anywhere, e.g.:"
+    log "  echo 'export PATH=\"${BIN_DIR}:\$PATH\"' >> ~/.profile"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds a Homebrew install path: `brew install scanii/tap/scanii-cli`. Goreleaser auto-publishes the formula to `scanii/homebrew-tap` on every tagged release.
- Adds a `curl | sh` install path: `curl -fsSL https://raw.githubusercontent.com/scanii/scanii-cli/main/install.sh | sh`. POSIX script that detects OS/arch, verifies SHA-256, installs `sc` to `~/.local/bin` (override via `SCANII_CLI_BIN_DIR`, pin a version with `SCANII_CLI_VERSION`).
- Pins the goreleaser build matrix to `amd64`+`arm64` so the shell installer has a stable archive-name contract.
- Renames the checksums artifact to `checksums.txt` (was `scanii-cli_<version>_checksums.txt`) so the installer URL doesn't vary per version.
- Bumps `.goreleaser.yaml` schema to version 2 — required by current goreleaser; the prior v1 schema is no longer accepted by `goreleaser check`.

npm and WinGet were scoped out for a follow-up.

## Bootstrap required before the first release ships these paths

These are one-time setup steps; **the brew formula push will fail at release time without them**:

1. Create the **public repo `github.com/scanii/homebrew-tap`** (empty is fine — goreleaser writes `Formula/scanii-cli.rb` on the first release).
2. Mint a **fine-grained PAT** scoped to that single repo with `Contents: read & write`, store as `HOMEBREW_TAP_GITHUB_TOKEN` on `scanii/scanii-cli` repo secrets.

The shell installer has no bootstrap requirement — it always reads `install.sh` from `main` and works from the first release of `v1.7.0+` onward (older releases predate the stable `checksums.txt` filename and aren't supported by the installer).

## Test plan

- [x] `goreleaser check` — clean (two pre-existing deprecation warnings for `brews` and `dockers`, both unrelated to this PR).
- [x] `goreleaser release --snapshot --clean --skip=publish,docker` — snapshot built; `dist/homebrew/scanii-cli.rb` and `dist/checksums.txt` produced as expected.
- [x] End-to-end installer test against a local HTTP server serving the snapshot `dist/` — downloaded archive, verified SHA-256, extracted, installed; `sc version` printed the snapshot version.
- [x] Negative test with a tampered checksum — installer exits non-zero with a clear `checksum mismatch` error and no binary is installed.
- [x] `go test ./...` — all green.
- [x] Pipe-safety check — `install.sh` contains no `read`, no `< /dev/stdin`, no `<&0`; safe for `curl | sh`.
- [ ] Post-merge with a release-candidate tag (`v1.7.0-rc.1`): goreleaser succeeds, formula lands in `scanii/homebrew-tap`, `brew install scanii/tap/scanii-cli` from a clean machine works.