### PR TITLE
fix(ci): bump goreleaser-action to v6 for goreleaser v2 support

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.1]
+
+### Fixed
+
+- Republish of the 1.7.0 release. The 1.7.0 tag pushed an empty release because `goreleaser-action@v5` with `version: latest` locks to goreleaser v1.x, which rejected the v2 config schema introduced in 1.7.0. Bumped the action to `@v6` pinned to `~> v2`. No source or behavior changes; same install paths as 1.7.0.
+
 ## [1.7.0]
 
 ### Added


### PR DESCRIPTION
## Summary

The v1.7.0 release failed because `goreleaser-action@v5` with `version: latest` actually locks to **goreleaser v1.x** for back-compat — the action printed `Will lock to '~> v1'` and downloaded `v1.26.2`, which rejects the v2 config schema introduced in #82:

```
only configurations files on `version: 1` are supported, yours is `version: 2`,
please update your configuration
```

Bump to `goreleaser-action@v6` (defaults to goreleaser v2) and pin `version: '~> v2'` so future minor bumps stay within the v2 line.

## Recovery options after merging

The v1.7.0 tag and GitHub release object exist but have no artifacts attached. Two clean paths:

1. **Cut v1.7.1** (recommended — no destructive ops). Leave the empty v1.7.0 release as a tombstone or delete its release object via UI. Tag v1.7.1 from new main. CHANGELOG entry: "fix: republish v1.7.0 release artifacts (release workflow was broken)."
2. **Re-cut v1.7.0**. Delete the tag (`git push --delete origin v1.7.0`) and the GitHub release object, then re-tag v1.7.0 from new main. Cleaner version history but involves force-deleting a published tag.

I'd take option 1 — v1.7.0 was effectively a no-op publish, treating it as a tombstone is honest and avoids any retag confusion for anyone who pulled it in the small window between tag push and now.

## Test plan

- [ ] Merge, then trigger the chosen release path (v1.7.1 or re-tag v1.7.0)
- [ ] Verify the workflow downloads goreleaser v2.x (look for `goreleaser_Linux_x86_64.tar.gz` from a v2 release URL in the action log)
- [ ] Confirm the brew formula lands in `scanii/homebrew-tap`
- [ ] `brew install scanii/tap/scanii-cli` on a clean machine