### PR TITLE
fix: measure single file progress in bytes uploaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,25 @@ Processing recursive directory /path/to/directory with ~12 files | ~50.3 MB
 Files 7/12  [████████████████████████░░░░░░░░░░░░░░░░░░]  58% (29.7 MB/50.3 MB)
 ```
 
-Example output on completion:
+On completion, any file that came back with findings is listed, so a directory
+scan tells you *where* the malware was and not just how much of it there was:
 
 ```
 Using endpoint: api-us1.scanii.com and API key: mykey
 Processing recursive directory /path/to/directory with ~12 files | ~50.3 MB
 Files 12/12  [████████████████████████████████████████]  100% (50.3 MB/50.3 MB)
+
+## Files with findings
+
+# /path/to/directory/quarantine/sample.txt:
+
+  id:             e353d97476fe40c6abd20418efe82b96
+  checksum/sha1:  7da9d3b0c68b1d0543acb65af4220a4745607557
+  content type:   text/plain; charset=utf-8
+  content length:  36 B
+  creation date:   Sat, 08 Aug 2026 09:07:46 EDT
+  findings:       content.malicious.eicar-test-signature
+  metadata:       none
 
 ✔ Completed in 3.1 s, 12 file(s) analyzed. Throughput 16.2 MB/s
 ✔ Files with findings: 1, unable to process: 0 and successfully processed: 12

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Scanii CLI (`sc`) helps you build, test, and manage your [Scanii](https://ww
 
 - Interact with the Scanii API: scan files, manage auth tokens, and check account info
 - Start a local server that simulates the Scanii API for integration testing
-- Process entire directories of files with concurrent workers and progress tracking
+- Process single files or entire directories with concurrent workers and byte-level upload progress
 
 ## Installation
 
@@ -86,6 +86,37 @@ Synchronous scan (blocks until the result is ready):
 sc files process /path/to/file.pdf
 ```
 
+Progress is measured in bytes as they go out on the wire, so a large file
+advances smoothly while it uploads:
+
+```
+Using endpoint: api-us1.scanii.com and API key: mykey
+Processing file /path/to/backup.tar
+Uploading backup.tar  [█████████████████░░░░░░░░░░░░░]  58% (183.2 MB/314.6 MB)
+```
+
+Once the last byte is sent, the wait is on the server, so the bar gives way to a
+spinner until the result lands:
+
+```
+⠹ Analyzing backup.tar
+```
+
+```
+# /path/to/backup.tar:
+
+  id:             ff03467da11f417aa99845c91793ce0c
+  checksum/sha1:  0c4f4f069728d13bf481738ac926381477fb8975
+  content type:   application/octet-stream
+  content length:  314.6 MB
+  creation date:   Sat, 08 Aug 2026 08:41:43 EDT
+  findings:       none
+  metadata:       none
+
+✔ Completed in 4.2 s, 1 file(s) analyzed. Throughput 74.9 MB/s
+✔ Files with findings: 0, unable to process: 0 and successfully processed: 1
+```
+
 Asynchronous scan (returns immediately with a pending result ID):
 
 ```shell
@@ -132,29 +163,24 @@ Skip hidden files and attach metadata:
 sc files process --ignore-hidden --metadata env=production,scan_type=nightly /path/to/directory
 ```
 
-Example output:
+Directories are tracked the same way. The bar fills with the bytes uploaded so
+far across every file, and the label counts the files that have come back:
 
 ```
-Using endpoint: localhost:4000 and API key: key
-success in 4.4ms
-Credentials worked against http://localhost:4000/v2.2/
-Processing directory:  .
-Found 39 file(s)
-Processing files 100% |████████████████████████████████████████| (39/39, 918 it/s)
+Using endpoint: api-us1.scanii.com and API key: mykey
+Processing recursive directory /path/to/directory with ~12 files | ~50.3 MB
+Files 7/12  [████████████████████████░░░░░░░░░░░░░░░░░░]  58% (29.7 MB/50.3 MB)
+```
 
-Completed in 150ms
-Files with findings: 4, unable to process: 0 and successfully processed: 39
-Files with findings:
-------
-  path:           samples/eicar.txt
-  id:             fd33128a8da445d3b8308fe6d1588829
-  checksum/sah1:  3395856ce81f2b7382dee72602f798b642f14140
-  content type:   text/plain; charset=utf-8
-  content length: 68 B
-  creation date:  2024-02-08T13:38:02.074502Z
-  findings:       content.malicious.eicar-test-signature
-  metadata:       none
-------
+Example output on completion:
+
+```
+Using endpoint: api-us1.scanii.com and API key: mykey
+Processing recursive directory /path/to/directory with ~12 files | ~50.3 MB
+Files 12/12  [████████████████████████████████████████]  100% (50.3 MB/50.3 MB)
+
+✔ Completed in 3.1 s, 12 file(s) analyzed. Throughput 16.2 MB/s
+✔ Files with findings: 1, unable to process: 0 and successfully processed: 12
 ```
 
 ### 6. Manage auth tokens

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Skip hidden files and attach metadata:
 sc files process --ignore-hidden --metadata env=production,scan_type=nightly /path/to/directory
 ```
 
+Empty files are skipped rather than uploaded — the API rejects empty content, so
+sending it only buys a `400` — and the CLI reports how many it passed over:
+
+```
+Processing recursive directory /path/to/directory with ~12 files | ~50.3 MB
+Skipping 3 empty file(s)
+```
+
 Directories are tracked the same way. The bar fills with the bytes uploaded so
 far across every file, and the label counts the files that have come back:
 

--- a/internal/commands/file/findings.go
+++ b/internal/commands/file/findings.go
@@ -1,0 +1,42 @@
+package file
+
+import (
+	"cmp"
+	"slices"
+	"sync"
+)
+
+// findingsReport collects the results that carry findings during a directory
+// run, so they can be listed once the progress bar is out of the way. A
+// directory run reports only counts while it works, and a count alone does not
+// tell you which file the malware was in.
+//
+// Results arrive from one goroutine per in-flight file, hence the lock.
+type findingsReport struct {
+	mu      sync.Mutex
+	results []resultRecord
+}
+
+// add records a result if it carries findings.
+func (r *findingsReport) add(record *resultRecord) {
+	if len(record.findings) == 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.results = append(r.results, *record)
+}
+
+// sorted returns the collected results ordered by path, so that a run over the
+// same tree prints the same report regardless of the order files finished in.
+func (r *findingsReport) sorted() []resultRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	sorted := slices.Clone(r.results)
+	slices.SortFunc(sorted, func(a, b resultRecord) int {
+		return cmp.Compare(a.path, b.path)
+	})
+	return sorted
+}

--- a/internal/commands/file/findings_test.go
+++ b/internal/commands/file/findings_test.go
@@ -1,0 +1,71 @@
+package file
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestFindingsReportOnlyKeepsResultsWithFindings(t *testing.T) {
+	report := &findingsReport{}
+	report.add(&resultRecord{path: "clean.txt"})
+	report.add(&resultRecord{path: "empty-findings.txt", findings: []string{}})
+	report.add(&resultRecord{path: "malware.exe", findings: []string{"content.malicious.eicar-test-signature"}})
+
+	got := report.sorted()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 result, got %d: %+v", len(got), got)
+	}
+	if got[0].path != "malware.exe" {
+		t.Fatalf("expected malware.exe, got %s", got[0].path)
+	}
+}
+
+func TestFindingsReportSortsByPath(t *testing.T) {
+	report := &findingsReport{}
+	for _, path := range []string{"c.txt", "a.txt", "b.txt"} {
+		report.add(&resultRecord{path: path, findings: []string{"finding"}})
+	}
+
+	got := report.sorted()
+	for i, want := range []string{"a.txt", "b.txt", "c.txt"} {
+		if got[i].path != want {
+			t.Fatalf("expected %s at position %d, got %s", want, i, got[i].path)
+		}
+	}
+}
+
+func TestFindingsReportConcurrentAdd(t *testing.T) {
+	// results arrive from one goroutine per in-flight file
+	report := &findingsReport{}
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Go(func() {
+			report.add(&resultRecord{path: fmt.Sprintf("file-%02d.txt", i), findings: []string{"finding"}})
+		})
+	}
+	wg.Wait()
+
+	got := report.sorted()
+	if len(got) != 50 {
+		t.Fatalf("expected 50 results, got %d", len(got))
+	}
+	for i, result := range got {
+		if want := fmt.Sprintf("file-%02d.txt", i); result.path != want {
+			t.Fatalf("expected %s at position %d, got %s", want, i, result.path)
+		}
+	}
+}
+
+func TestFindingsReportSortedIsASnapshot(t *testing.T) {
+	report := &findingsReport{}
+	report.add(&resultRecord{path: "a.txt", findings: []string{"finding"}})
+
+	snapshot := report.sorted()
+	report.add(&resultRecord{path: "b.txt", findings: []string{"finding"}})
+
+	if len(snapshot) != 1 {
+		t.Fatalf("expected the snapshot to be unaffected, got %d results", len(snapshot))
+	}
+}

--- a/internal/commands/file/process.go
+++ b/internal/commands/file/process.go
@@ -105,11 +105,7 @@ func process(
 
 	if info.IsDir() {
 		isDirectory = true
-		err = fsWalker(path, ignoreHidden, func(_ string, it os.DirEntry) {
-			fi, err := it.Info()
-			if err != nil {
-				return
-			}
+		emptyFiles, err := fsWalker(path, ignoreHidden, func(_ string, fi os.FileInfo) {
 			bytesTotal += uint64(fi.Size()) //nolint:gosec
 			filesTotal++
 		})
@@ -118,10 +114,20 @@ func process(
 			return fmt.Errorf("failed to walk directory: %w", err)
 		}
 		terminal.Info(fmt.Sprintf("Processing recursive directory %s with ~%s files | ~%s", path, terminal.FormatNumber(int64(filesTotal)), terminal.FormatBytes(bytesTotal))) //nolint:gosec
+		if emptyFiles > 0 {
+			terminal.Info(fmt.Sprintf("Skipping %s empty file(s)", terminal.FormatNumber(int64(emptyFiles))))
+		}
 	} else {
 		if ignoreHidden && strings.HasPrefix(filepath.Base(path), ".") {
 			slog.Debug("ignoring hidden file", "path", path)
 			terminal.Info(fmt.Sprintf("Skipping hidden file %s", path))
+			return nil
+		}
+		// the API rejects empty content with a 400, so there is nothing to learn
+		// from sending it
+		if info.Size() == 0 {
+			slog.Debug("ignoring empty file", "path", path)
+			terminal.Info(fmt.Sprintf("Skipping empty file %s", path))
 			return nil
 		}
 		filesTotal = 1
@@ -131,7 +137,7 @@ func process(
 
 	fileChannel := make(chan string)
 	go func() {
-		err = fsWalker(path, ignoreHidden, func(filePath string, _ os.DirEntry) {
+		_, err := fsWalker(path, ignoreHidden, func(filePath string, _ os.FileInfo) {
 			filesStarted.Add(1)
 			fileChannel <- filePath
 		})
@@ -197,8 +203,11 @@ func process(
 	return nil
 }
 
-func fsWalker(root string, ignoreHidden bool, handler func(path string, d os.DirEntry)) error {
-	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+// fsWalker calls handler for every file under root that is worth sending for
+// analysis, and reports how many empty files it skipped along the way. Empty
+// content is rejected by the API with a 400, so uploading it only buys an error.
+func fsWalker(root string, ignoreHidden bool, handler func(path string, info os.FileInfo)) (emptyFiles int, err error) {
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -209,9 +218,25 @@ func fsWalker(root string, ignoreHidden bool, handler func(path string, d os.Dir
 			slog.Debug("ignoring hidden file", "path", path)
 			return nil
 		}
-		if !d.IsDir() {
-			handler(path, d)
+		if d.IsDir() {
+			return nil
 		}
+
+		info, err := d.Info()
+		if err != nil {
+			// a file we cannot stat is one we cannot size or open; the walk
+			// carries on rather than failing the whole run over it
+			slog.Debug("ignoring unreadable file", "path", path, "error", err)
+			return nil
+		}
+		if info.Size() == 0 {
+			slog.Debug("ignoring empty file", "path", path)
+			emptyFiles++
+			return nil
+		}
+
+		handler(path, info)
 		return nil
 	})
+	return emptyFiles, err
 }

--- a/internal/commands/file/process.go
+++ b/internal/commands/file/process.go
@@ -148,7 +148,9 @@ func process(
 		close(fileChannel)
 	}()
 
-	bytesProcessed := uint64(0)
+	// a directory run only reports counts while it works, so the files that
+	// actually carry findings are collected and listed at the end
+	findings := &findingsReport{}
 
 	// Progress is measured in bytes handed to the transport rather than in files
 	// completed, so that a single large file — or a directory of a few of them —
@@ -175,10 +177,9 @@ func process(
 			filesFinished.Add(1)
 		}
 
-		// increment bytes processed
-		bytesProcessed += result.contentLength
 		if len(result.findings) > 0 {
 			filesWithFindings.Add(1)
+			findings.add(&result)
 		}
 		if isDirectory {
 			slog.Debug("progress", "files_started", filesStarted.Load(), "files_finished", filesFinished.Load(), "files_failed", filesFailed.Load(), "files_with_findings", filesWithFindings.Load(), "total_files", filesTotal)
@@ -195,6 +196,16 @@ func process(
 	tracker.stop()
 	elapsed := time.Since(startTime)
 	throughput := float64(bytesTotal) / elapsed.Seconds()
+
+	// a single file has already printed its own result above
+	if isDirectory {
+		if withFindings := findings.sorted(); len(withFindings) > 0 {
+			terminal.Section("Files with findings")
+			for i := range withFindings {
+				printFileResult(&withFindings[i])
+			}
+		}
+	}
 
 	fmt.Println()
 	terminal.Success(fmt.Sprintf("Completed in %s, %s file(s) analyzed. Throughput %s/s", terminal.FormatDuration(elapsed), terminal.FormatNumber(int64(filesFinished.Load())), terminal.FormatBytes(uint64(throughput)))) //nolint:gosec

--- a/internal/commands/file/process.go
+++ b/internal/commands/file/process.go
@@ -144,9 +144,24 @@ func process(
 
 	bytesProcessed := uint64(0)
 
+	// Progress is measured in bytes handed to the transport rather than in files
+	// completed, so that a single large file — or a directory of a few of them —
+	// advances smoothly instead of flipping from 0 to 100%.
+	tracker := newProgressTracker(ctx, isDirectory, filesTotal, bytesTotal, filepath.Base(path))
+	defer tracker.stop()
+
 	startTime := time.Now()
 	fs, err := newService(p)
-	err = fs.process(ctx, fileChannel, concurrencyLimit, callback, async, metadata, func(result resultRecord) {
+	if err != nil {
+		return fmt.Errorf("failed to create service: %w", err)
+	}
+	err = fs.process(ctx, fileChannel, processOptions{
+		maxConcurrency: concurrencyLimit,
+		callback:       callback,
+		async:          async,
+		metadata:       metadata,
+		onBytes:        tracker.addBytes,
+	}, func(result resultRecord) {
 		if result.err != nil {
 			slog.Error("failed to process file", "file", result.path, "error", result.err)
 			filesFailed.Add(1)
@@ -161,10 +176,9 @@ func process(
 		}
 		if isDirectory {
 			slog.Debug("progress", "files_started", filesStarted.Load(), "files_finished", filesFinished.Load(), "files_failed", filesFailed.Load(), "files_with_findings", filesWithFindings.Load(), "total_files", filesTotal)
-			if !slog.Default().Enabled(ctx, slog.LevelDebug) {
-				terminal.ProgressBar("Files", filesFinished.Load()+filesFailed.Load(), filesTotal)
-			}
+			tracker.fileDone(filesFinished.Load() + filesFailed.Load())
 		} else {
+			tracker.stop()
 			printFileResult(&result)
 		}
 
@@ -172,6 +186,7 @@ func process(
 	if err != nil {
 		return err
 	}
+	tracker.stop()
 	elapsed := time.Since(startTime)
 	throughput := float64(bytesTotal) / elapsed.Seconds()
 

--- a/internal/commands/file/process_test.go
+++ b/internal/commands/file/process_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFsWalkerSingleFile(t *testing.T) {
 	var visited []string
-	err := fsWalker(fakeMalwareSample, false, func(path string, d os.DirEntry) {
+	_, err := fsWalker(fakeMalwareSample, false, func(path string, d os.FileInfo) {
 		visited = append(visited, d.Name())
 	})
 	if err != nil {
@@ -41,7 +41,7 @@ func TestFsWalkerDirectory(t *testing.T) {
 	}
 
 	var visited []string
-	err := fsWalker(dir, false, func(path string, d os.DirEntry) {
+	_, err := fsWalker(dir, false, func(path string, d os.FileInfo) {
 		visited = append(visited, d.Name())
 	})
 	if err != nil {
@@ -62,7 +62,7 @@ func TestFsWalkerSkipsDirectories(t *testing.T) {
 	}
 
 	var visited []string
-	err := fsWalker(dir, false, func(path string, d os.DirEntry) {
+	_, err := fsWalker(dir, false, func(path string, d os.FileInfo) {
 		visited = append(visited, d.Name())
 		if d.IsDir() {
 			t.Fatalf("handler should not be called with directory, got %s", d.Name())
@@ -77,7 +77,7 @@ func TestFsWalkerSkipsDirectories(t *testing.T) {
 }
 
 func TestFsWalkerNonExistentPath(t *testing.T) {
-	err := fsWalker("/tmp/does_not_exist_at_all", false, func(path string, d os.DirEntry) {
+	_, err := fsWalker("/tmp/does_not_exist_at_all", false, func(path string, d os.FileInfo) {
 		t.Fatal("should not be called")
 	})
 	if err == nil {
@@ -96,7 +96,7 @@ func TestFsWalkerPassesFilePath(t *testing.T) {
 	}
 
 	var paths []string
-	err := fsWalker(dir, false, func(path string, d os.DirEntry) {
+	_, err := fsWalker(dir, false, func(path string, d os.FileInfo) {
 		paths = append(paths, path)
 	})
 	if err != nil {
@@ -131,7 +131,7 @@ func TestFsWalkerIgnoreHidden(t *testing.T) {
 	}
 
 	var visited []string
-	err := fsWalker(dir, true, func(path string, d os.DirEntry) {
+	_, err := fsWalker(dir, true, func(path string, d os.FileInfo) {
 		visited = append(visited, d.Name())
 	})
 	if err != nil {
@@ -170,7 +170,7 @@ func TestFsWalkerIgnoreHiddenDotfiles(t *testing.T) {
 	}
 
 	var visited []string
-	err := fsWalker(dir, true, func(path string, d os.DirEntry) {
+	_, err := fsWalker(dir, true, func(path string, d os.FileInfo) {
 		visited = append(visited, d.Name())
 	})
 	if err != nil {
@@ -193,7 +193,7 @@ func TestFsWalkerIgnoreHiddenSingleFile(t *testing.T) {
 	}
 
 	var visited []string
-	err := fsWalker(hiddenFile, true, func(path string, d os.DirEntry) {
+	_, err := fsWalker(hiddenFile, true, func(path string, d os.FileInfo) {
 		visited = append(visited, d.Name())
 	})
 	if err != nil {
@@ -214,7 +214,7 @@ func TestFsWalkerIncludeHidden(t *testing.T) {
 	}
 
 	var visited []string
-	err := fsWalker(dir, false, func(path string, d os.DirEntry) {
+	_, err := fsWalker(dir, false, func(path string, d os.FileInfo) {
 		visited = append(visited, d.Name())
 	})
 	if err != nil {
@@ -223,5 +223,55 @@ func TestFsWalkerIncludeHidden(t *testing.T) {
 	sort.Strings(visited)
 	if len(visited) != 2 {
 		t.Fatalf("expected 2 files, got %d: %v", len(visited), visited)
+	}
+}
+
+func TestFsWalkerSkipsEmptyFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "content.txt"), []byte("test"), 0600); err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+	for _, name := range []string{"empty1.txt", "empty2.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0600); err != nil {
+			t.Fatalf("failed to create file: %s", err)
+		}
+	}
+
+	var visited []string
+	emptyFiles, err := fsWalker(dir, false, func(path string, d os.FileInfo) {
+		visited = append(visited, d.Name())
+	})
+	if err != nil {
+		t.Fatalf("fsWalker failed: %s", err)
+	}
+
+	// empty content is rejected by the API, so it never leaves the machine
+	if len(visited) != 1 || visited[0] != "content.txt" {
+		t.Fatalf("expected only content.txt, got %v", visited)
+	}
+	if emptyFiles != 2 {
+		t.Fatalf("expected 2 empty files reported, got %d", emptyFiles)
+	}
+}
+
+func TestFsWalkerSkipsEmptySingleFile(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(empty, nil, 0600); err != nil {
+		t.Fatalf("failed to create file: %s", err)
+	}
+
+	var visited []string
+	emptyFiles, err := fsWalker(empty, false, func(path string, d os.FileInfo) {
+		visited = append(visited, d.Name())
+	})
+	if err != nil {
+		t.Fatalf("fsWalker failed: %s", err)
+	}
+	if len(visited) != 0 {
+		t.Fatalf("expected no files, got %v", visited)
+	}
+	if emptyFiles != 1 {
+		t.Fatalf("expected 1 empty file reported, got %d", emptyFiles)
 	}
 }

--- a/internal/commands/file/progress.go
+++ b/internal/commands/file/progress.go
@@ -1,0 +1,106 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/uvasoftware/scanii-cli/internal/terminal"
+)
+
+// progressTracker renders the progress of a process run. Progress is measured in
+// bytes handed to the HTTP transport, which is the only part of the work whose
+// completion the CLI can actually observe: once the last byte is sent, the wait
+// is on the server, so a single file swaps the bar for a spinner rather than
+// sitting at 100%.
+//
+// A tracker with a nil bar is inert, which is how debug runs are handled — the
+// bar would fight with the log stream for the same lines.
+type progressTracker struct {
+	bar         *terminal.Progress
+	isDirectory bool
+	filesTotal  uint64
+	bytesTotal  uint64
+	name        string
+
+	mu      sync.Mutex
+	spinner *terminal.Spinner
+	stopped bool
+}
+
+func newProgressTracker(ctx context.Context, isDirectory bool, filesTotal, bytesTotal uint64, name string) *progressTracker {
+	t := &progressTracker{
+		isDirectory: isDirectory,
+		filesTotal:  filesTotal,
+		bytesTotal:  bytesTotal,
+		name:        name,
+	}
+
+	if bytesTotal == 0 || slog.Default().Enabled(ctx, slog.LevelDebug) {
+		return t
+	}
+
+	t.bar = terminal.NewProgress(t.label(0), bytesTotal)
+	return t
+}
+
+// label reports the bar label for the given number of finished files.
+func (t *progressTracker) label(filesDone uint64) string {
+	if !t.isDirectory {
+		return fmt.Sprintf("Uploading %s", t.name)
+	}
+	return fmt.Sprintf("Files %s/%s", terminal.FormatNumber(int64(filesDone)), terminal.FormatNumber(int64(t.filesTotal))) //nolint:gosec
+}
+
+// addBytes records bytes written to the wire. It is called from one goroutine
+// per in-flight file.
+func (t *progressTracker) addBytes(n uint64) {
+	if t.bar == nil {
+		return
+	}
+	t.bar.Add(n)
+
+	// a single file has nothing left to measure once it is fully uploaded
+	if !t.isDirectory && t.bar.Current() >= t.bytesTotal {
+		t.analyzing()
+	}
+}
+
+// fileDone updates the file counter shown alongside the bar in directory mode.
+func (t *progressTracker) fileDone(filesDone uint64) {
+	if t.bar == nil {
+		return
+	}
+	t.bar.SetLabel(t.label(filesDone))
+}
+
+// analyzing finishes the bar and spins until stop, for the server-side wait that
+// follows the upload.
+func (t *progressTracker) analyzing() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped || t.spinner != nil {
+		return
+	}
+	t.bar.Done()
+	t.spinner = terminal.NewSpinner(fmt.Sprintf("Analyzing %s", t.name))
+}
+
+// stop clears any spinner and finishes the bar. It is idempotent, so callers can
+// both defer it and call it at the point a result is about to be printed.
+func (t *progressTracker) stop() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		return
+	}
+	t.stopped = true
+
+	if t.spinner != nil {
+		t.spinner.Stop()
+	}
+	if t.bar != nil {
+		t.bar.Done()
+	}
+}

--- a/internal/commands/file/progress_test.go
+++ b/internal/commands/file/progress_test.go
@@ -1,0 +1,151 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestProgressReaderCountsBytes(t *testing.T) {
+	var seen atomic.Uint64
+	r := &progressReader{
+		reader:  strings.NewReader(strings.Repeat("a", 5000)),
+		onBytes: func(n uint64) { seen.Add(n) },
+	}
+
+	n, err := io.Copy(io.Discard, r)
+	if err != nil {
+		t.Fatalf("copy failed: %s", err)
+	}
+	if n != 5000 {
+		t.Fatalf("expected 5000 bytes copied, got %d", n)
+	}
+	if seen.Load() != 5000 {
+		t.Fatalf("expected 5000 bytes reported, got %d", seen.Load())
+	}
+}
+
+func TestProgressReaderIgnoresEmptyReads(t *testing.T) {
+	var calls atomic.Uint64
+	r := &progressReader{
+		reader:  bytes.NewReader(nil),
+		onBytes: func(uint64) { calls.Add(1) },
+	}
+
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		t.Fatalf("copy failed: %s", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("expected no reports for an empty reader, got %d", calls.Load())
+	}
+}
+
+// quietLogger pins the default logger above debug for the duration of a test.
+// Other tests in this package turn debug logging on, which deliberately
+// suppresses the progress bar.
+func quietLogger(t *testing.T) {
+	t.Helper()
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})))
+}
+
+func TestProgressTrackerLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		isDirectory bool
+		filesDone   uint64
+		want        string
+	}{
+		{name: "single file", isDirectory: false, want: "Uploading sample.txt"},
+		{name: "directory start", isDirectory: true, filesDone: 0, want: "Files 0/1,500"},
+		{name: "directory partial", isDirectory: true, filesDone: 750, want: "Files 750/1,500"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := newProgressTracker(context.Background(), tc.isDirectory, 1500, 1000, "sample.txt")
+			if got := tracker.label(tc.filesDone); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestProgressTrackerInertWhenNothingToShow(t *testing.T) {
+	tests := []struct {
+		name       string
+		bytesTotal uint64
+		debug      bool
+	}{
+		{name: "no bytes to upload", bytesTotal: 0},
+		{name: "debug logging owns the terminal", bytesTotal: 1000, debug: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.debug {
+				original := slog.Default()
+				t.Cleanup(func() { slog.SetDefault(original) })
+				slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			}
+
+			tracker := newProgressTracker(context.Background(), false, 1, tc.bytesTotal, "sample.txt")
+			if tracker.bar != nil {
+				t.Fatal("expected no progress bar")
+			}
+
+			// the tracker is still driven by the upload, so it must stay safe to call
+			tracker.addBytes(100)
+			tracker.fileDone(1)
+			tracker.stop()
+		})
+	}
+}
+
+func TestProgressTrackerStopIsIdempotent(t *testing.T) {
+	quietLogger(t)
+	tracker := newProgressTracker(context.Background(), false, 1, 1000, "sample.txt")
+	tracker.stop()
+	tracker.stop()
+
+	// analyzing after stop must not resurrect a spinner that would never be stopped
+	tracker.analyzing()
+	if tracker.spinner != nil {
+		t.Fatal("expected no spinner after stop")
+	}
+}
+
+func TestProgressTrackerSwapsToSpinnerWhenUploadCompletes(t *testing.T) {
+	quietLogger(t)
+	tracker := newProgressTracker(context.Background(), false, 1, 1000, "sample.txt")
+
+	tracker.addBytes(600)
+	if tracker.spinner != nil {
+		t.Fatal("expected no spinner while the upload is in flight")
+	}
+
+	tracker.addBytes(400)
+	if tracker.spinner == nil {
+		t.Fatal("expected a spinner once the upload completed")
+	}
+
+	tracker.stop()
+}
+
+func TestProgressTrackerDirectoryKeepsBarForServerWait(t *testing.T) {
+	quietLogger(t)
+	// with many files in flight the file counter keeps moving, so the bar stays
+	tracker := newProgressTracker(context.Background(), true, 2, 1000, "dir")
+
+	tracker.addBytes(1000)
+	if tracker.spinner != nil {
+		t.Fatal("expected no spinner in directory mode")
+	}
+
+	tracker.stop()
+}

--- a/internal/commands/file/service.go
+++ b/internal/commands/file/service.go
@@ -31,6 +31,34 @@ func newService(profile *profile.Profile) (*service, error) {
 
 type consumer func(record resultRecord)
 
+// processOptions carries the per-run settings for service.process.
+type processOptions struct {
+	maxConcurrency int
+	callback       string
+	async          bool
+	metadata       map[string]string
+	// onBytes, when set, is called with the number of file bytes handed to the
+	// HTTP transport. It is called from one goroutine per in-flight file.
+	onBytes func(n uint64)
+}
+
+// progressReader reports bytes as they are read. The request body is an io.Pipe
+// drained by the HTTP transport, so a read only advances once the previous chunk
+// has been written to the wire — which makes this an upload progress signal
+// rather than a read-ahead count.
+type progressReader struct {
+	reader  io.Reader
+	onBytes func(n uint64)
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.reader.Read(b)
+	if n > 0 {
+		p.onBytes(uint64(n)) //nolint:gosec
+	}
+	return n, err
+}
+
 func (s *service) retrieve(ctx context.Context, id string) (*resultRecord, error) {
 	resp, err := s.client.RetrieveFile(ctx, id)
 	if err != nil {
@@ -55,10 +83,10 @@ func (s *service) retrieve(ctx context.Context, id string) (*resultRecord, error
 
 // process is the main function that processes the files in the stream
 // an error is returned only in catastrophic situations, individual file errors are recorded in the resultRecord and passed to the consumer for handling
-func (s *service) process(ctx context.Context, stream chan string, maxConcurrency int, callback string, async bool, metadata map[string]string, consumer consumer) error {
+func (s *service) process(ctx context.Context, stream chan string, opts processOptions, consumer consumer) error {
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(maxConcurrency)
+	g.SetLimit(opts.maxConcurrency)
 
 	for path := range stream {
 		g.Go(func() error {
@@ -89,6 +117,9 @@ func (s *service) process(ctx context.Context, stream chan string, maxConcurrenc
 
 				sha1 := sha1hash.New() //nolint:gosec
 				fdAndShaReader := io.TeeReader(fd, sha1)
+				if opts.onBytes != nil {
+					fdAndShaReader = &progressReader{reader: fdAndShaReader, onBytes: opts.onBytes}
+				}
 
 				sendErr := func(prefix string, err error) {
 					_ = pipeWriter.CloseWithError(err)
@@ -106,15 +137,15 @@ func (s *service) process(ctx context.Context, stream chan string, maxConcurrenc
 					return
 				}
 
-				for k, v := range metadata {
+				for k, v := range opts.metadata {
 					if err = mpb.WriteField(fmt.Sprintf("metadata[%s]", k), v); err != nil {
 						sendErr("write metadata", err)
 						return
 					}
 				}
 
-				if callback != "" {
-					if err = mpb.WriteField("callback", callback); err != nil {
+				if opts.callback != "" {
+					if err = mpb.WriteField("callback", opts.callback); err != nil {
 						sendErr("write callback", err)
 						return
 					}
@@ -151,7 +182,7 @@ func (s *service) process(ctx context.Context, stream chan string, maxConcurrenc
 				return true
 			}
 
-			if async {
+			if opts.async {
 				result, err := s.client.ProcessFileAsync(ctx, contentType, pipeReader)
 				if err != nil {
 					_ = pipeWriter.CloseWithError(err)

--- a/internal/commands/file/service_test.go
+++ b/internal/commands/file/service_test.go
@@ -2,7 +2,9 @@ package file
 
 import (
 	"context"
+	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -25,7 +27,7 @@ func TestServiceProcessSyncSingleFile(t *testing.T) {
 	var results []resultRecord
 	var mu sync.Mutex
 
-	err := svc.process(context.Background(), stream, 1, "", false, map[string]string{"m1": "v1"}, func(r resultRecord) {
+	err := svc.process(context.Background(), stream, processOptions{maxConcurrency: 1, metadata: map[string]string{"m1": "v1"}}, func(r resultRecord) {
 		mu.Lock()
 		results = append(results, r)
 		mu.Unlock()
@@ -58,7 +60,7 @@ func TestServiceProcessAsyncSingleFile(t *testing.T) {
 	var results []resultRecord
 	var mu sync.Mutex
 
-	err := svc.process(context.Background(), stream, 1, "", true, map[string]string{"m1": "v1"}, func(r resultRecord) {
+	err := svc.process(context.Background(), stream, processOptions{maxConcurrency: 1, async: true, metadata: map[string]string{"m1": "v1"}}, func(r resultRecord) {
 		mu.Lock()
 		results = append(results, r)
 		mu.Unlock()
@@ -95,7 +97,7 @@ func TestServiceProcessMultipleFiles(t *testing.T) {
 	var results []resultRecord
 	var mu sync.Mutex
 
-	err := svc.process(context.Background(), stream, 2, "", false, nil, func(r resultRecord) {
+	err := svc.process(context.Background(), stream, processOptions{maxConcurrency: 2}, func(r resultRecord) {
 		mu.Lock()
 		results = append(results, r)
 		mu.Unlock()
@@ -126,7 +128,7 @@ func TestServiceProcessNonExistentFile(t *testing.T) {
 	var results []resultRecord
 	var mu sync.Mutex
 
-	err := svc.process(context.Background(), stream, 1, "", false, nil, func(r resultRecord) {
+	err := svc.process(context.Background(), stream, processOptions{maxConcurrency: 1}, func(r resultRecord) {
 		mu.Lock()
 		results = append(results, r)
 		mu.Unlock()
@@ -155,7 +157,7 @@ func TestServiceRetrieve(t *testing.T) {
 	var results []resultRecord
 	var mu sync.Mutex
 
-	err := svc.process(context.Background(), stream, 1, "", false, map[string]string{"m1": "v1"}, func(r resultRecord) {
+	err := svc.process(context.Background(), stream, processOptions{maxConcurrency: 1, metadata: map[string]string{"m1": "v1"}}, func(r resultRecord) {
 		mu.Lock()
 		results = append(results, r)
 		mu.Unlock()
@@ -191,7 +193,7 @@ func TestServiceRetrieveAsync(t *testing.T) {
 	var results []resultRecord
 	var mu sync.Mutex
 
-	err := svc.process(context.Background(), stream, 1, "", true, map[string]string{"m1": "v1"}, func(r resultRecord) {
+	err := svc.process(context.Background(), stream, processOptions{maxConcurrency: 1, async: true, metadata: map[string]string{"m1": "v1"}}, func(r resultRecord) {
 		mu.Lock()
 		results = append(results, r)
 		mu.Unlock()
@@ -211,4 +213,42 @@ func TestServiceRetrieveAsync(t *testing.T) {
 	}
 
 	checkResponseContent(t, retrieved)
+}
+
+func TestServiceProcessReportsUploadedBytes(t *testing.T) {
+	svc := newTestService(t)
+
+	stream := make(chan string, 1)
+	stream <- fakeMalwareSample
+	close(stream)
+
+	var reported atomic.Uint64
+	var results []resultRecord
+	var mu sync.Mutex
+
+	err := svc.process(context.Background(), stream, processOptions{
+		maxConcurrency: 1,
+		onBytes:        func(n uint64) { reported.Add(n) },
+	}, func(r resultRecord) {
+		mu.Lock()
+		results = append(results, r)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("process failed: %s", err)
+	}
+
+	info, err := os.Stat(fakeMalwareSample)
+	if err != nil {
+		t.Fatalf("failed to stat sample: %s", err)
+	}
+
+	// every byte of the file is reported exactly once, which is what makes the
+	// progress bar track the upload rather than guessing at it
+	if got, want := reported.Load(), uint64(info.Size()); got != want { //nolint:gosec
+		t.Fatalf("expected %d bytes reported, got %d", want, got)
+	}
+	if len(results) != 1 || results[0].err != nil {
+		t.Fatalf("expected one successful result, got %+v", results)
+	}
 }

--- a/internal/terminal/progress.go
+++ b/internal/terminal/progress.go
@@ -1,0 +1,82 @@
+package terminal
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// redrawInterval bounds how often a Progress repaints, so that a fast upload or
+// a directory of thousands of small files does not flood the terminal.
+const redrawInterval = 100 * time.Millisecond
+
+// Progress is a progress bar measured in bytes. It is safe for concurrent use:
+// bytes may be reported from many upload goroutines while the label is updated
+// from another. Nothing is drawn until Add reports the first bytes, and the
+// zero total case draws nothing at all.
+type Progress struct {
+	total   uint64
+	current atomic.Uint64
+
+	mu       sync.Mutex
+	label    string
+	lastDraw time.Time
+	finished bool
+}
+
+// NewProgress creates a progress bar for total bytes. A zero total is valid and
+// renders nothing.
+func NewProgress(label string, total uint64) *Progress {
+	return &Progress{label: label, total: total}
+}
+
+// Add records n more bytes of progress and repaints, at most once per
+// redrawInterval.
+func (p *Progress) Add(n uint64) {
+	current := p.current.Add(n)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.draw(current, false)
+}
+
+// SetLabel replaces the label and repaints, at most once per redrawInterval.
+func (p *Progress) SetLabel(label string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.label = label
+	p.draw(p.current.Load(), false)
+}
+
+// Done paints the bar one final time and terminates the line. It is idempotent,
+// so a caller that finishes the bar early can safely defer another call.
+func (p *Progress) Done() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.finished {
+		return
+	}
+	p.finished = true
+	p.draw(p.current.Load(), true)
+}
+
+// Current returns the bytes reported so far.
+func (p *Progress) Current() uint64 {
+	return p.current.Load()
+}
+
+// draw repaints the bar. The caller must hold p.mu.
+func (p *Progress) draw(current uint64, final bool) {
+	if p.total == 0 || p.finished && !final {
+		return
+	}
+	if !final && time.Since(p.lastDraw) < redrawInterval {
+		return
+	}
+	p.lastDraw = time.Now()
+
+	current = min(current, p.total)
+	stats := fmt.Sprintf("%d%% (%s/%s)", percentOf(current, p.total), FormatBytes(current), FormatBytes(p.total))
+	renderProgress(p.label, current, p.total, stats, final)
+}

--- a/internal/terminal/progress_test.go
+++ b/internal/terminal/progress_test.go
@@ -1,0 +1,107 @@
+package terminal
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestProgressReportsBytes(t *testing.T) {
+	out := captureOut(func() {
+		p := NewProgress("Uploading", 1000)
+		p.Add(400)
+		p.Done()
+	})
+
+	// non-TTY prints only the final line
+	if strings.Count(out, "\n") != 1 {
+		t.Fatalf("expected a single line, got %q", out)
+	}
+	if !strings.Contains(out, "Uploading") {
+		t.Fatalf("expected the label, got %q", out)
+	}
+	if !strings.Contains(out, "40% (400 B/1 KB)") {
+		t.Fatalf("expected byte formatted stats, got %q", out)
+	}
+}
+
+func TestProgressDoneIsIdempotent(t *testing.T) {
+	out := captureOut(func() {
+		p := NewProgress("Uploading", 10)
+		p.Done()
+		p.Done()
+		p.Add(10)
+		p.Done()
+	})
+
+	if strings.Count(out, "\n") != 1 {
+		t.Fatalf("expected exactly one final line, got %q", out)
+	}
+}
+
+func TestProgressSetLabel(t *testing.T) {
+	out := captureOut(func() {
+		p := NewProgress("Files 0/6", 100)
+		p.SetLabel("Files 6/6")
+		p.Done()
+	})
+
+	if !strings.Contains(out, "Files 6/6") {
+		t.Fatalf("expected the updated label, got %q", out)
+	}
+}
+
+func TestProgressZeroTotal(t *testing.T) {
+	out := captureOut(func() {
+		p := NewProgress("Uploading", 0)
+		p.Add(10)
+		p.Done()
+	})
+
+	if out != "" {
+		t.Fatalf("expected no output for a zero total, got %q", out)
+	}
+}
+
+func TestProgressClampsOvershoot(t *testing.T) {
+	// a file that grows between stat and read must not panic or exceed 100%
+	out := captureOut(func() {
+		p := NewProgress("Uploading", 100)
+		p.Add(250)
+		p.Done()
+	})
+
+	if !strings.Contains(out, "100%") {
+		t.Fatalf("expected the bar to clamp at 100%%, got %q", out)
+	}
+}
+
+func TestProgressCurrent(t *testing.T) {
+	p := NewProgress("Uploading", 100)
+	p.Add(30)
+	p.Add(20)
+	if p.Current() != 50 {
+		t.Fatalf("expected 50 bytes, got %d", p.Current())
+	}
+}
+
+func TestProgressConcurrentAdd(t *testing.T) {
+	// directory mode reports bytes from one goroutine per in-flight file
+	captureOut(func() {
+		p := NewProgress("Files", 10_000)
+		var wg sync.WaitGroup
+		for range 10 {
+			wg.Go(func() {
+				for range 100 {
+					p.Add(1)
+				}
+			})
+		}
+		wg.Wait()
+		p.Done()
+
+		if p.Current() != 1000 {
+			t.Errorf("expected 1000 bytes, got %d", p.Current())
+		}
+	})
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -228,35 +228,45 @@ func ReadLine(prompt string) string {
 
 // ProgressBar displays a progress bar. In TTY mode it overwrites the current line.
 // In non-TTY mode it only prints the final line when current == total.
-// Silently returns when total <= 0.
+// Silently returns when total is 0.
 func ProgressBar(label string, current, total uint64) {
-	if total <= 0 {
+	if total == 0 {
 		return
 	}
+	current = min(current, total)
+	stats := fmt.Sprintf("%d%% (%d/%d)", percentOf(current, total), current, total)
+	renderProgress(label, current, total, stats, current >= total)
+}
 
-	percent := int(float64(current) / float64(total) * 100)
-	stats := fmt.Sprintf("%d%% (%d/%d)", percent, current, total)
-
+// renderProgress draws a single frame of a progress bar. In TTY mode it
+// overwrites the current line, terminating it when final is set. In non-TTY
+// mode it prints one line, and only when final is set.
+func renderProgress(label string, current, total uint64, stats string, final bool) {
 	if !IsTTY() {
-		if current == total {
+		if final {
 			_, _ = fmt.Fprintf(stdout, "%s %s\n", label, stats)
 		}
 		return
 	}
 
 	termWidth := getTerminalWidth()
-	barWidth := termWidth - len(label) - len(stats) - 7 // 7 chars for spaces and brackets
-	if barWidth < 10 {
-		barWidth = 10
-	}
+	barWidth := max(termWidth-len(label)-len(stats)-7, 10) // 7 chars for spaces and brackets
 
 	filled := int(float64(current) / float64(total) * float64(barWidth))
 	bar := strings.Repeat(string(blockFilled), filled) + strings.Repeat(string(blockEmpty), barWidth-filled)
 
-	_, _ = fmt.Fprintf(stdout, "\r%s  [%s]  %s", label, bar, stats)
-	if current == total {
+	// clear to end of line so a shrinking label does not leave a tail behind
+	_, _ = fmt.Fprintf(stdout, "\r\033[2K%s  [%s]  %s", label, bar, stats)
+	if final {
 		_, _ = fmt.Fprintln(stdout)
 	}
+}
+
+func percentOf(current, total uint64) int {
+	if total == 0 {
+		return 0
+	}
+	return int(float64(current) / float64(total) * 100)
 }
 
 // Spinner displays an animated braille spinner with a message.


### PR DESCRIPTION
Fixes #20

Single file mode had no progress indicator at all — the CLI printed `Processing file …` and then sat silent until the result arrived. The bar was only drawn for directories, where it counted *files*, so a directory holding one or two large files flipped 0 → 100% just the same.

## Approach

Progress is now measured in **bytes uploaded**. The multipart body is streamed through an `io.Pipe` drained by the HTTP transport, so a read from the file only advances once the previous chunk has gone out on the wire — counting those reads measures the upload rather than estimating it.

Once the last byte is sent, the remaining wait is server-side and has no measurable progress, so a single file swaps the finished bar for the existing spinner instead of sitting at 100%.

```
Uploading backup.tar  [█████████████████░░░░░░░░░░░░░]  58% (183.2 MB/314.6 MB)
⠹ Analyzing backup.tar
```

Directory mode keeps its file counter — now in the label — and gains a bar that moves *between* file completions:

```
Files 7/12  [████████████████████████░░░░░░░░░░░░░░░░░░]  58% (29.7 MB/50.3 MB)
```

## Changes

- **`internal/terminal/progress.go`** (new) — `Progress`, a byte-oriented bar that is safe for concurrent use (directory mode reports from one goroutine per in-flight file) and throttles redraws to 100ms. That throttle also stops a directory of thousands of small files from repainting once per result, which is what the old bar did.
- **`internal/terminal/terminal.go`** — the bar rendering is shared by the existing `ProgressBar` and the new type. Current is clamped to total, so a file that grows between `stat` and read can no longer drive `strings.Repeat` negative; each frame also clears to end of line so a shrinking label leaves no tail.
- **`internal/commands/file/progress.go`** (new) — `progressTracker` owns the bar/spinner handoff and is inert under `--verbose`, where the bar and the log stream would fight for the same lines.
- **`internal/commands/file/service.go`** — `progressReader` reports bytes as they are read. `service.process` took seven positional parameters including a bool and a func, so it now takes a `processOptions` struct.
- **`README.md`** — the directory example output was several releases stale (it described a `Credentials worked against …` preamble and an `it/s` bar that no longer exist). Replaced with captured output, plus a new single-file example.

## Also fixed in passing

`fs, err := newService(p)` assigned an error that the very next statement overwrote, so a failure there would have panicked on a nil service instead of returning.

## Verification

`go test -race -buildvcs ./...`, `go vet`, and golangci-lint all pass. New tests cover the byte accounting end to end through `service.process` (every byte of the file reported exactly once), the throttle/idempotent-`Done`/clamping behavior of `Progress`, and the tracker's bar-to-spinner handoff.

Verified by hand against the mock server under a pty: a 300 MB single file advanced 0 → 13 → 29 → 46 → 61 → 77 → 93 → 100%, then held a spinner through a deliberately slow server's scan before printing the result.

## Also in this PR: skip empty files (second commit)

The API rejects empty content with a `400`, so uploading it only buys a round trip and a line in the `unable to process` count. `fsWalker` now skips zero-byte files and reports how many it passed over, so the difference between the files on disk and the files analyzed is stated rather than silent:

```
Processing recursive directory /path/to/directory with ~12 files | ~50.3 MB
Skipping 3 empty file(s)
```

A single empty file is skipped with a message, mirroring how hidden files are already handled. Because the walker now stats each entry to decide, it hands the `FileInfo` to its handler instead of the `DirEntry`, which also saves the counting pass a second stat per file.

Verified against the mock server: a lone empty file and a directory with three empties mixed in are both skipped with no request sent, where before each one came back `400`.


## Also in this PR: list the files that had findings (third commit)

A directory run reported `Files with findings: 4` and stopped there — it told you malware was present without telling you where. (The README used to document a `Files with findings:` listing; the CLI stopped producing one at some point, so this restores documented behavior.) Results carrying findings are now collected as they arrive and printed after the bar finishes, sorted by path so the same tree produces the same report regardless of completion order:

```
Files 12/12  [████████████████████████████████████████]  100% (50.3 MB/50.3 MB)

## Files with findings

# /path/to/directory/quarantine/sample.txt:

  id:             e353d97476fe40c6abd20418efe82b96
  checksum/sha1:  7da9d3b0c68b1d0543acb65af4220a4745607557
  content type:   text/plain; charset=utf-8
  content length:  36 B
  creation date:   Sat, 08 Aug 2026 09:07:46 EDT
  findings:       content.malicious.eicar-test-signature
  metadata:       none

✔ Completed in 3.1 s, 12 file(s) analyzed. Throughput 16.2 MB/s
✔ Files with findings: 1, unable to process: 0 and successfully processed: 12
```

Single-file runs are unchanged — they already print their own result, and the listing is skipped for them.

This also removes a data race: the consumer callback accumulated `bytesProcessed` from every upload goroutine without synchronization. Nothing ever read the value, so it is gone rather than made atomic.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

