### PR TITLE
fix: error out on an invalid engine config instead of ignoring it

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,11 @@ Output:
 
 ```
 Scanii local server starting
-API Key:      key
-API Secret:   secret
-Engine Rules: 5
-Address:      http://localhost:4000
+API Key:       key
+API Secret:    secret
+Engine Rules:  5
+Callback Wait: 100ms
+Address:       http://localhost:4000
 
 Sample usage: curl -u key:secret http://localhost:4000/v2.2/ping
 
@@ -214,7 +215,7 @@ sc server --key my-key --secret my-secret --address 0.0.0.0:8080
 | `-s, --secret` | `secret` | API secret |
 | `-e, --engine` | built-in | Path to a custom engine rules JSON file |
 | `-d, --data` | temp dir | Directory for storing processing results |
-| `-w, --callback-wait` | `100ms` | Delay before firing callbacks |
+| `-w, --callback-wait` | `100ms` | Delay before firing callbacks; overrides `callback_wait` in the engine config |
 
 ### API endpoints
 
@@ -330,6 +331,7 @@ The JSON format is:
 
 ```json
 {
+  "callback_wait": "100ms",
   "rules": [
     {
       "format": "sha256",
@@ -339,6 +341,9 @@ The JSON format is:
   ]
 }
 ```
+
+`callback_wait` is optional and must be a duration string such as `"100ms"` or
+`"2s"`; `--callback-wait` overrides it when passed.
 
 Supported hash formats are `sha1` and `sha256`. Generate a hash for your test file with:
 
@@ -358,7 +363,7 @@ error: opening engine config: open foo: no such file or directory
 
 ### Callbacks
 
-The local server supports callbacks. When a `callback` URL is included in an async or fetch request, the server POSTs a JSON payload to that URL containing the processing result (id, findings, checksum, content_type, content_length, creation_date, and metadata). The callback fires after a configurable delay (default 100ms, controlled by `--callback-wait`).
+The local server supports callbacks. When a `callback` URL is included in an async or fetch request, the server POSTs a JSON payload to that URL containing the processing result (id, findings, checksum, content_type, content_length, creation_date, and metadata). The callback fires after a configurable delay: 100ms by default, `callback_wait` in an `--engine` config, or `--callback-wait` which overrides both. The effective value is shown as `Callback Wait:` in the startup banner.
 
 Callbacks are fire-and-forget: if the target URL is unreachable, the delivery fails silently and the server continues operating normally.
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,16 @@ Supported hash formats are `sha1` and `sha256`. Generate a hash for your test fi
 shasum -a 256 /path/to/your/test-file
 ```
 
+The rules in your file replace the built-in ones rather than adding to them, so
+`Engine Rules:` in the startup banner reflects your file alone. A config that is
+missing, unreadable, or not a valid rules file stops the server from starting
+instead of quietly falling back to the built-in rules:
+
+```
+% sc server --engine foo
+error: opening engine config: open foo: no such file or directory
+```
+
 ### Callbacks
 
 The local server supports callbacks. When a `callback` URL is included in an async or fetch request, the server POSTs a JSON payload to that URL containing the processing result (id, findings, checksum, content_type, content_length, creation_date, and metadata). The callback fires after a configurable delay (default 100ms, controlled by `--callback-wait`).

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -29,8 +29,9 @@ type Flags struct {
 	CallBackWait time.Duration
 }
 
-// RunServer starts the mock Scanii server. This function blocks.
-func RunServer(flags *Flags) {
+// RunServer starts the mock Scanii server. This function blocks until the
+// server stops, and returns an error if it could not be started.
+func RunServer(flags *Flags) error {
 	if flags.Key == "" {
 		terminal.Info("No API key provided, generating one...")
 		flags.Key = fmt.Sprintf("akk_%s", identifiers.GenerateShort())
@@ -45,18 +46,17 @@ func RunServer(flags *Flags) {
 		// Ensure the system temp directory exists — minimal Docker images
 		// (e.g. scratch, distroless) may not include /tmp.
 		if err := os.MkdirAll(os.TempDir(), 0755); err != nil {
-			panic(err)
+			return fmt.Errorf("creating temp directory: %w", err)
 		}
 		dir, err := os.MkdirTemp("", "scanii-cli")
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("creating storage directory: %w", err)
 		}
 		flags.Data = dir
 	} else {
 		if _, err := os.Stat(flags.Data); errors.Is(err, os.ErrNotExist) {
-			err := os.MkdirAll(flags.Data, 0755)
-			if err != nil {
-				panic(err)
+			if err := os.MkdirAll(flags.Data, 0755); err != nil {
+				return fmt.Errorf("creating storage directory %s: %w", flags.Data, err)
 			}
 		}
 	}
@@ -65,8 +65,16 @@ func RunServer(flags *Flags) {
 
 	eng, err := engine.New()
 	if err != nil {
-		slog.Error("could not create engine")
-		os.Exit(2)
+		return fmt.Errorf("creating engine: %w", err)
+	}
+
+	// a bad --engine config is worth failing on: starting anyway would serve the
+	// built-in rules while looking like it had honored the flag
+	if flags.Engine != "" {
+		if err := loadEngineConfig(eng, flags.Engine); err != nil {
+			return err
+		}
+		slog.Debug("loaded engine config", "path", flags.Engine, "rules", eng.RuleCount())
 	}
 
 	Setup(mux, eng, flags.Key, flags.Secret, flags.Data, "http://"+flags.Address)
@@ -109,20 +117,35 @@ func RunServer(flags *Flags) {
 
 	listen, err := net.Listen("tcp", flags.Address)
 	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(2)
+		return fmt.Errorf("listening on %s: %w", flags.Address, err)
 	}
 
 	if flags.ReadyChan != nil {
 		flags.ReadyChan <- true
 	}
 
-	err = srv.Serve(listen)
-	if err != nil {
-		slog.Error("server error", "error", err)
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(3)
+	if err := srv.Serve(listen); err != nil {
+		return fmt.Errorf("serving: %w", err)
 	}
+
+	return nil
+}
+
+// loadEngineConfig replaces the engine's built-in rules with the config file at
+// path. Unknown fields are rejected by the decoder, so a file that is valid JSON
+// but not an engine config is reported rather than silently ignored.
+func loadEngineConfig(eng *engine.Engine, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening engine config: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if err := eng.LoadConfig(file); err != nil {
+		return fmt.Errorf("loading engine config %s: %w", path, err)
+	}
+
+	return nil
 }
 
 // serverEICAR decodes the embedded base64 EICAR payload and returns it
@@ -138,8 +161,8 @@ func Command() *cobra.Command {
 	serverF := Flags{}
 	serverCmd := &cobra.Command{
 		Use: "server",
-		Run: func(cmd *cobra.Command, args []string) {
-			RunServer(&serverF)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return RunServer(&serverF)
 		},
 		Short: "Start a mock server suitable for testing purposes",
 	}

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -20,13 +20,16 @@ import (
 
 // Flags holds configuration for the mock server.
 type Flags struct {
-	Address      string
-	Engine       string
-	Key          string
-	Secret       string
-	Data         string
-	ReadyChan    chan bool
-	CallBackWait time.Duration
+	Address   string
+	Engine    string
+	Key       string
+	Secret    string
+	Data      string
+	ReadyChan chan bool
+	// CallBackWait overrides the engine's callback delay. Nil means the engine
+	// config decides, which is what keeps an unpassed flag from overriding a
+	// value set in an --engine file.
+	CallBackWait *time.Duration
 }
 
 // RunServer starts the mock Scanii server. This function blocks until the
@@ -77,6 +80,11 @@ func RunServer(flags *Flags) error {
 		slog.Debug("loaded engine config", "path", flags.Engine, "rules", eng.RuleCount())
 	}
 
+	// applied after the config file so that an explicit flag wins over it
+	if flags.CallBackWait != nil {
+		eng.SetCallbackWait(*flags.CallBackWait)
+	}
+
 	Setup(mux, eng, flags.Key, flags.Secret, flags.Data, "http://"+flags.Address)
 
 	// wrap the mux with request logging middleware
@@ -103,6 +111,7 @@ func RunServer(flags *Flags) error {
 	terminal.KeyValue("API Key:", flags.Key)
 	terminal.KeyValue("API Secret:", flags.Secret)
 	terminal.KeyValue("Engine Rules:", fmt.Sprintf("%d", eng.RuleCount()))
+	terminal.KeyValue("Callback Wait:", eng.CallbackWait().String())
 	//goland:noinspection HttpUrlsUsage
 	terminal.KeyValue("Address:", fmt.Sprintf("http://%s", flags.Address))
 	//goland:noinspection HttpUrlsUsage
@@ -159,9 +168,14 @@ func serverEICAR(w http.ResponseWriter, _ *http.Request) {
 // Command returns the server cobra command.
 func Command() *cobra.Command {
 	serverF := Flags{}
+	var callbackWait time.Duration
 	serverCmd := &cobra.Command{
 		Use: "server",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// only override the engine config when the flag was actually passed
+			if cmd.Flags().Changed("callback-wait") {
+				serverF.CallBackWait = &callbackWait
+			}
 			return RunServer(&serverF)
 		},
 		Short: "Start a mock server suitable for testing purposes",
@@ -169,7 +183,7 @@ func Command() *cobra.Command {
 
 	serverCmd.PersistentFlags().StringVarP(&serverF.Address, "address", "a", "0.0.0.0:4000", "Address to listen on")
 	serverCmd.PersistentFlags().StringVarP(&serverF.Engine, "engine", "e", "", "Optional engine config to load")
-	serverCmd.PersistentFlags().DurationVarP(&serverF.CallBackWait, "callback-wait", "w", 100*time.Millisecond, "Amount of time a callback should wait before firing")
+	serverCmd.PersistentFlags().DurationVarP(&callbackWait, "callback-wait", "w", 100*time.Millisecond, "Amount of time a callback should wait before firing, overrides the engine config")
 	serverCmd.PersistentFlags().StringVarP(&serverF.Data, "data", "d", "", "Result storage path, defaults to a temp directory")
 	serverCmd.PersistentFlags().StringVarP(&serverF.Key, "key", "k", "key", "API key to use, if not provided will be dynamically generated")
 	serverCmd.PersistentFlags().StringVarP(&serverF.Secret, "secret", "s", "secret", "API secret to use, if not provided will be dynamically generated")

--- a/internal/commands/server/server_test.go
+++ b/internal/commands/server/server_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/uvasoftware/scanii-cli/internal/engine"
+)
+
+// writeConfig writes contents to a temp file and returns its path.
+func writeConfig(t *testing.T, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("failed to write config: %s", err)
+	}
+	return path
+}
+
+func TestLoadEngineConfigRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantsErr string
+	}{
+		{
+			name:     "missing file",
+			path:     filepath.Join(t.TempDir(), "does-not-exist.json"),
+			wantsErr: "opening engine config",
+		},
+		{
+			name:     "not json at all",
+			path:     writeConfig(t, "broken.json", "not json at all"),
+			wantsErr: "loading engine config",
+		},
+		{
+			name:     "valid json but not an engine config",
+			path:     writeConfig(t, "wrong-shape.json", `{"nope": 1}`),
+			wantsErr: "unknown field",
+		},
+		{
+			name:     "empty file",
+			path:     writeConfig(t, "empty.json", ""),
+			wantsErr: "loading engine config",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			eng, err := engine.New()
+			if err != nil {
+				t.Fatalf("engine.New: %s", err)
+			}
+
+			err = loadEngineConfig(eng, tc.path)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.wantsErr) {
+				t.Fatalf("expected the error to mention %q, got %q", tc.wantsErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadEngineConfigReplacesRules(t *testing.T) {
+	eng, err := engine.New()
+	if err != nil {
+		t.Fatalf("engine.New: %s", err)
+	}
+
+	builtIn := eng.RuleCount()
+	if builtIn == 0 {
+		t.Fatal("expected the built-in config to carry rules")
+	}
+
+	path := writeConfig(t, "custom.json", `{
+		"rules": [
+			{"format": "sha1", "content": "7da9d3b0c68b1d0543acb65af4220a4745607557", "result": "content.custom.my-own-rule"}
+		]
+	}`)
+
+	if err := loadEngineConfig(eng, path); err != nil {
+		t.Fatalf("loadEngineConfig failed: %s", err)
+	}
+	if eng.RuleCount() != 1 {
+		t.Fatalf("expected the custom config to replace the built-in rules, got %d rules", eng.RuleCount())
+	}
+}
+
+func TestRunServerFailsOnBadEngineConfig(t *testing.T) {
+	// the whole point of https://github.com/scanii/scanii-cli/issues/15: the
+	// server used to ignore the flag and start with the built-in rules. It
+	// returns before binding a port, so no address is needed.
+	err := RunServer(&Flags{
+		Address: "127.0.0.1:0",
+		Key:     "key",
+		Secret:  "secret",
+		Data:    t.TempDir(),
+		Engine:  filepath.Join(t.TempDir(), "does-not-exist.json"),
+	})
+
+	if err == nil {
+		t.Fatal("expected RunServer to fail on a missing engine config")
+	}
+	if !strings.Contains(err.Error(), "opening engine config") {
+		t.Fatalf("expected an engine config error, got %q", err)
+	}
+}

--- a/internal/commands/server/server_test.go
+++ b/internal/commands/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/uvasoftware/scanii-cli/internal/engine"
 )
@@ -108,4 +109,41 @@ func TestRunServerFailsOnBadEngineConfig(t *testing.T) {
 	if !strings.Contains(err.Error(), "opening engine config") {
 		t.Fatalf("expected an engine config error, got %q", err)
 	}
+}
+
+func TestCallbackWaitFlagOverridesEngineConfig(t *testing.T) {
+	config := writeConfig(t, "slow-callbacks.json", `{"callback_wait": "5s", "rules": []}`)
+
+	tests := []struct {
+		name string
+		flag *time.Duration
+		want time.Duration
+	}{
+		{name: "config wins when the flag is not passed", flag: nil, want: 5 * time.Second},
+		{name: "flag wins when passed", flag: ptr(2 * time.Second), want: 2 * time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			eng, err := engine.New()
+			if err != nil {
+				t.Fatalf("engine.New: %s", err)
+			}
+
+			if err := loadEngineConfig(eng, config); err != nil {
+				t.Fatalf("loadEngineConfig failed: %s", err)
+			}
+			if tc.flag != nil {
+				eng.SetCallbackWait(*tc.flag)
+			}
+
+			if got := eng.CallbackWait(); got != tc.want {
+				t.Fatalf("expected a callback wait of %s, got %s", tc.want, got)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/internal/engine/callback.go
+++ b/internal/engine/callback.go
@@ -30,16 +30,14 @@ func (e *Engine) newRunner() chan callbackItem {
 	const UA = "scanii/jackfruit (see https://www.scanii.com)"
 
 	queue := make(chan callbackItem, 100)
-	wait := time.Duration(0)
-	if e.config.CallbackWait != nil {
-		wait = *e.config.CallbackWait
-	}
-	slog.Debug("callback wait", "wait", wait)
 	client := &http.Client{Timeout: 30 * time.Second}
 
 	go func() {
 		for msg := range queue {
-			slog.Debug("sending callback", "destination", msg.destination)
+			// read per delivery rather than once, so a config loaded (or a flag
+			// applied) after the engine was built still takes effect
+			wait := e.CallbackWait()
+			slog.Debug("sending callback", "destination", msg.destination, "wait", wait)
 			time.Sleep(wait)
 			slog.Debug("post wait", "destination", msg.destination)
 

--- a/internal/engine/default.json
+++ b/internal/engine/default.json
@@ -1,5 +1,5 @@
 {
-  "callback_wait": 100,
+  "callback_wait": "100ms",
   "rules": [
     {
       "format": "sha1",

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -19,7 +20,10 @@ import (
 var defaultConfig string
 
 type Engine struct {
-	config        *Config
+	config *Config
+	// callbackWait is held separately, in nanoseconds, because the callback
+	// runner reads it from its own goroutine every time it delivers.
+	callbackWait  atomic.Int64
 	callbackQueue chan callbackItem
 }
 
@@ -29,8 +33,32 @@ type Rule struct {
 	Result  string `json:"result"`
 }
 type Config struct {
-	Rules        []Rule         `json:"rules"`
-	CallbackWait *time.Duration `json:"callback_wait"`
+	Rules        []Rule    `json:"rules"`
+	CallbackWait *Duration `json:"callback_wait"`
+}
+
+// Duration is a time.Duration that reads from JSON as a duration string, so a
+// config says "100ms" rather than 100000000. A bare number would be nanoseconds,
+// which is a trap: "callback_wait": 100 means 100ns, not 100ms.
+type Duration time.Duration
+
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return fmt.Errorf(`callback_wait must be a duration string such as "100ms": %w`, err)
+	}
+
+	parsed, err := time.ParseDuration(text)
+	if err != nil {
+		return fmt.Errorf("callback_wait %q is not a valid duration: %w", text, err)
+	}
+
+	*d = Duration(parsed)
+	return nil
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
 }
 
 func New() (*Engine, error) {
@@ -58,7 +86,23 @@ func (e *Engine) LoadConfig(reader io.Reader) error {
 	if err != nil {
 		return err
 	}
+
+	if e.config.CallbackWait != nil {
+		e.SetCallbackWait(time.Duration(*e.config.CallbackWait))
+	}
 	return nil
+}
+
+// SetCallbackWait overrides how long the engine waits before delivering a
+// callback. It takes effect for callbacks that have not been delivered yet,
+// which is what lets --callback-wait win over a config file loaded before it.
+func (e *Engine) SetCallbackWait(wait time.Duration) {
+	e.callbackWait.Store(int64(wait))
+}
+
+// CallbackWait returns the delay applied before delivering a callback.
+func (e *Engine) CallbackWait() time.Duration {
+	return time.Duration(e.callbackWait.Load())
 }
 
 func (e *Engine) RuleCount() int {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNew(t *testing.T) {
@@ -177,5 +178,91 @@ func BenchmarkEngine(b *testing.B) {
 		if err != nil {
 			b.Fatal(err.Error())
 		}
+	}
+}
+
+func TestLoadConfigCallbackWait(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		want    time.Duration
+		wantErr string
+	}{
+		{
+			name:   "duration string",
+			config: `{"callback_wait": "2s", "rules": []}`,
+			want:   2 * time.Second,
+		},
+		{
+			name:   "sub second duration",
+			config: `{"callback_wait": "250ms", "rules": []}`,
+			want:   250 * time.Millisecond,
+		},
+		{
+			// a bare number used to be read as nanoseconds, so "100" quietly meant 100ns
+			name:    "bare number is rejected",
+			config:  `{"callback_wait": 100, "rules": []}`,
+			wantErr: "duration string",
+		},
+		{
+			name:    "unparseable duration",
+			config:  `{"callback_wait": "soon", "rules": []}`,
+			wantErr: "not a valid duration",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, err := New()
+			if err != nil {
+				t.Fatalf("New failed: %s", err)
+			}
+
+			err = engine.LoadConfig(strings.NewReader(tc.config))
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected the error to mention %q, got %q", tc.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("LoadConfig failed: %s", err)
+			}
+			if engine.CallbackWait() != tc.want {
+				t.Fatalf("expected a callback wait of %s, got %s", tc.want, engine.CallbackWait())
+			}
+		})
+	}
+}
+
+func TestDefaultConfigCallbackWait(t *testing.T) {
+	engine, err := New()
+	if err != nil {
+		t.Fatalf("New failed: %s", err)
+	}
+
+	// regression guard: default.json used to say 100, which is 100ns not 100ms
+	if got := engine.CallbackWait(); got != 100*time.Millisecond {
+		t.Fatalf("expected the built-in callback wait to be 100ms, got %s", got)
+	}
+}
+
+func TestSetCallbackWaitOverridesConfig(t *testing.T) {
+	engine, err := New()
+	if err != nil {
+		t.Fatalf("New failed: %s", err)
+	}
+
+	if err := engine.LoadConfig(strings.NewReader(`{"callback_wait": "5s", "rules": []}`)); err != nil {
+		t.Fatalf("LoadConfig failed: %s", err)
+	}
+
+	engine.SetCallbackWait(time.Second)
+	if got := engine.CallbackWait(); got != time.Second {
+		t.Fatalf("expected the override to win, got %s", got)
 	}
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -32,12 +32,15 @@ func StartServer() *Server {
 	endpoint := fmt.Sprintf("localhost:%d", 20_000+rand.Intn(1000)) //nolint:gosec
 	ready := make(chan bool)
 	go func() {
-		server.RunServer(&server.Flags{
+		// panic rather than let <-ready block forever on a server that never started
+		if err := server.RunServer(&server.Flags{
 			Key:       Key,
 			Secret:    Secret,
 			Address:   endpoint,
 			ReadyChan: ready,
-		})
+		}); err != nil {
+			panic(err)
+		}
 	}()
 	<-ready
 


### PR DESCRIPTION
Fixes #15

`sc server --engine foo` started normally. The cause is worse than a missing error check: `flags.Engine` was bound to the `--engine` flag and then never read by anything, so the flag was inert. The server always ran the built-in rules while looking like it had honored the flag — and the README has documented the rules file format all along.

## Changes

- **`internal/commands/server/server.go`** — load the file when `--engine` is set, and fail before binding a port if it is missing, unreadable, or not a valid rules file. `engine.LoadConfig` already sets `DisallowUnknownFields`, so a file that is valid JSON but not a rules file is caught too.
- `RunServer` now returns an error instead of calling `os.Exit(2)`/`os.Exit(3)` or panicking, so cobra reports failures the same way as every other command (`error: …`, exit 1). The `engine.New()` failure path also stopped discarding its error.
- **`internal/testutil`** — the test server goroutine panics on a start failure rather than leaving `<-ready` blocked forever.
- **`README.md`** — documents that custom rules *replace* the built-in ones, and that a bad config now stops startup.

## Behavior

```
% sc server --engine foo
error: opening engine config: open foo: no such file or directory          (exit 1)

% sc server --engine wrong-shape.json
error: loading engine config wrong-shape.json: json: unknown field "nope"  (exit 1)

% sc server --engine broken.json
error: loading engine config broken.json: invalid character 'o' in literal null (expecting 'u')
```

## Verification

`go test -race -buildvcs ./...`, `go vet`, and golangci-lint pass. New tests cover the four rejection paths (missing, malformed, wrong-shape, empty), that a valid config replaces the built-in rules, and that `RunServer` itself returns the error.

Checked end to end that the flag now actually works, not just that it fails loudly: with a config carrying a single custom rule the banner reported `Engine Rules: 1` (built-in is 5), and scanning the sample returned `content.custom.my-own-rule` in place of the built-in `content.malicious.local-test-file`.

## Also in this PR: `--callback-wait` (second commit)

`--callback-wait` had the identical defect — bound to a flag variable nothing read. Rather than drop it, it is wired up, because the engine config was no alternative: it was broken in two ways of its own.

- **The wait was captured once**, when the engine was built ([`newRunner`](internal/engine/callback.go)), so a `callback_wait` in an `--engine` file never applied — the file is loaded *after* `engine.New()`. It is now read from an atomic on every delivery, so a config or flag applied later takes effect.
- **`default.json` said `"callback_wait": 100`**, which unmarshals into a `time.Duration` as **100 nanoseconds**, not the 100ms the README promised. The field is now a duration string (`"100ms"`), so a hand-written config cannot fall into that trap; a bare number is rejected with a message that says what to use instead.

Precedence is built-in default → `callback_wait` in an `--engine` file → `--callback-wait`, and the flag only overrides when it was actually passed (`Flags().Changed`), otherwise its own default would silently beat a value set in a config file. The effective delay now appears in the startup banner:

```
Engine Rules:  5
Callback Wait: 100ms
```

**Behavior change worth noting at review:** callbacks were firing after 100ns and now wait the documented 100ms by default. Anything timing callbacks against the mock server gets 100ms slower, which is what the docs have always claimed.

Verified end to end: with `-w 3s`, a callback measured 3.02s from submission to delivery, against a receiver timing it independently. Tests cover the duration-string parsing (including that a bare number is rejected), a regression guard that the built-in wait is 100ms rather than 100ns, and the flag-over-config precedence in both directions.
