### PR TITLE
docs: add the brew trust step to the Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,24 @@ The Scanii CLI (`sc`) helps you build, test, and manage your [Scanii](https://ww
 ### Homebrew (macOS, Linux)
 
 ```shell
+brew trust --formula scanii/tap/scanii-cli
 brew install scanii/tap/scanii-cli
+```
+
+From Homebrew 6.0, formulae in third-party taps must be trusted before Homebrew
+will load them, so without the first command the install fails with `Refusing to
+load formula scanii/tap/scanii-cli from untrusted tap scanii/tap`. Trust is
+recorded locally in `~/.homebrew/trust.json` — it is your decision to make, and
+nobody can grant it on your behalf. Use `brew trust scanii/tap` instead to trust
+everything in the tap rather than just this formula.
+
+`brew trust` prompts for nothing, so it drops straight into a CI script. It has
+existed since Homebrew 5.1.15; on anything older, skip it and just install.
+
+Trust persists, so upgrades need nothing extra:
+
+```shell
+brew upgrade scanii-cli
 ```
 
 ### Shell installer (macOS, Linux)


### PR DESCRIPTION
The README told people to run `brew install scanii/tap/scanii-cli`. On Homebrew 6 that fails before it starts:

```
Error: Refusing to load formula scanii/tap/scanii-cli from untrusted tap scanii/tap.
Run `brew trust --formula scanii/tap/scanii-cli` or `brew trust scanii/tap` to trust it.
```

## Why this is on us to document, not fix

Trust is recorded per user in `~/.homebrew/trust.json`. The tap owner cannot pre-authorize it for anyone, so the only correct fix is to tell people the step exists.

Verified against the installed Homebrew (6.0.15) source rather than inferred:

- The check is `Homebrew::Trust.require_trusted_formula!`, called from `Formulary.load_formula` — the single chokepoint that evaluates a formula's Ruby. Every install, upgrade and reinstall path goes through it, so `install` is gated exactly like the `upgrade` that surfaced this.
- `brew info` is *not* gated, because it reads metadata without evaluating the formula. Worth knowing: it means `brew info` is not a valid smoke test for this.
- `brew trust` prompts for nothing (no TTY or confirmation logic in `cmd/trust.rb`), so it works unattended in CI.

## Version detail

I first wrote "Homebrew 5 and earlier doesn't have the command" and that was wrong. From Homebrew's git history:

- `cmd/trust.rb` first appears in **5.1.15**.
- `HOMEBREW_REQUIRE_TAP_TRUST` only gains `default: true` in **6.0.0** — before that the command existed but enforcement was opt-in.

So the README now says enforcement starts at 6.0 and the command exists from 5.1.15, which is what the source actually shows.

## Also

Documents `brew upgrade scanii-cli` and notes that trust persists, so upgrades need nothing extra.

Confirmed end to end on Homebrew 6.0.15: after trusting, the upgrade to the republished 1.8.0 formula succeeds and `sc version` reports 1.8.0.