### PR TITLE
Report API errors and track the files a run could not process

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.26
+          # take the newest 1.26.x rather than whatever the runner image ships,
+          # so that a stdlib vulnerability fixed in a patch release clears the
+          # audit job as soon as that release exists
+          check-latest: true
 
       - name: Audit
         run: make audit
@@ -32,6 +36,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.26
+          # take the newest 1.26.x rather than whatever the runner image ships,
+          # so that a stdlib vulnerability fixed in a patch release clears the
+          # audit job as soon as that release exists
+          check-latest: true
 
       - name: Run tests
         run: make test

--- a/README.md
+++ b/README.md
@@ -221,6 +221,21 @@ Files 12/12  [██████████████████████
 ✔ Files with findings: 1, unable to process: 0 and successfully processed: 12
 ```
 
+Files the API rejected are reported as they happen, with the reason the API gave
+and the request id to quote in a support ticket. When more than a handful fail,
+the ones that scrolled past are listed again at the end of the run:
+
+```
+error: /path/to/directory/huge.iso — status 413: File is too large (request id req_9f3a1c)
+
+✔ Completed in 3.1 s, 11 file(s) analyzed. Throughput 16.2 MB/s
+warning: Files with findings: 1, unable to process: 1 and successfully processed: 11
+error: 1 of 12 file(s) could not be processed
+```
+
+`sc files process` and `sc files async` exit non-zero if any file could not be
+processed, so a scan that half-failed does not pass for a clean one in CI.
+
 ### 6. Manage auth tokens
 
 Create a short-lived auth token (default timeout: 300 seconds):

--- a/internal/commands/file/common.go
+++ b/internal/commands/file/common.go
@@ -1,12 +1,19 @@
 package file
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 
+	"github.com/uvasoftware/scanii-cli/internal/client"
 	"github.com/uvasoftware/scanii-cli/internal/terminal"
 )
+
+// requestIDHeader carries the API's identifier for a single request, which is
+// what support needs to look a failure up on the server side.
+const requestIDHeader = "X-Scanii-Request-Id"
 
 type resultRecord struct {
 	path          string
@@ -19,6 +26,21 @@ type resultRecord struct {
 	contentLength uint64
 	creationDate  string
 	metadata      map[string]string
+}
+
+// apiError builds an error from a non-success API response, preferring the
+// message the API returned over the bare status code — "status 413: File is too
+// large" tells the caller what to do about it, "status code 413" does not. The
+// path is left out on purpose: every caller already knows which file it sent.
+func apiError(status int, header http.Header, apiErr *client.ErrorResponse) error {
+	msg := fmt.Sprintf("status %d", status)
+	if apiErr != nil && apiErr.Error != nil && *apiErr.Error != "" {
+		msg = fmt.Sprintf("%s: %s", msg, *apiErr.Error)
+	}
+	if id := header.Get(requestIDHeader); id != "" {
+		msg = fmt.Sprintf("%s (request id %s)", msg, id)
+	}
+	return errors.New(msg)
 }
 
 // extractMetadata parses the metadata string and returns a map of key/value pairs.

--- a/internal/commands/file/failures.go
+++ b/internal/commands/file/failures.go
@@ -1,0 +1,42 @@
+package file
+
+import (
+	"cmp"
+	"slices"
+	"sync"
+)
+
+// failureReport collects the files a run could not process, so they can be
+// listed once the progress bar is out of the way. A directory run reports only
+// counts while it works, and "unable to process: 6" does not tell you which six
+// files to retry.
+//
+// Results arrive from one goroutine per in-flight file, hence the lock.
+type failureReport struct {
+	mu      sync.Mutex
+	results []resultRecord
+}
+
+// add records a result if it failed.
+func (r *failureReport) add(record *resultRecord) {
+	if record.err == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.results = append(r.results, *record)
+}
+
+// sorted returns the collected failures ordered by path, so that a run over the
+// same tree prints the same report regardless of the order files finished in.
+func (r *failureReport) sorted() []resultRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	sorted := slices.Clone(r.results)
+	slices.SortFunc(sorted, func(a, b resultRecord) int {
+		return cmp.Compare(a.path, b.path)
+	})
+	return sorted
+}

--- a/internal/commands/file/failures_test.go
+++ b/internal/commands/file/failures_test.go
@@ -1,0 +1,71 @@
+package file
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestFailureReportOnlyKeepsFailures(t *testing.T) {
+	report := &failureReport{}
+	report.add(&resultRecord{path: "clean.txt"})
+	report.add(&resultRecord{path: "rejected.exe", err: errors.New("status 413")})
+
+	got := report.sorted()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 result, got %d: %+v", len(got), got)
+	}
+	if got[0].path != "rejected.exe" {
+		t.Fatalf("expected rejected.exe, got %s", got[0].path)
+	}
+}
+
+func TestFailureReportSortsByPath(t *testing.T) {
+	report := &failureReport{}
+	for _, path := range []string{"c.txt", "a.txt", "b.txt"} {
+		report.add(&resultRecord{path: path, err: errors.New("status 500")})
+	}
+
+	got := report.sorted()
+	for i, want := range []string{"a.txt", "b.txt", "c.txt"} {
+		if got[i].path != want {
+			t.Fatalf("expected %s at position %d, got %s", want, i, got[i].path)
+		}
+	}
+}
+
+func TestFailureReportConcurrentAdd(t *testing.T) {
+	// results arrive from one goroutine per in-flight file
+	report := &failureReport{}
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Go(func() {
+			report.add(&resultRecord{path: fmt.Sprintf("file-%02d.txt", i), err: errors.New("status 429")})
+		})
+	}
+	wg.Wait()
+
+	got := report.sorted()
+	if len(got) != 50 {
+		t.Fatalf("expected 50 results, got %d", len(got))
+	}
+	for i, result := range got {
+		if want := fmt.Sprintf("file-%02d.txt", i); result.path != want {
+			t.Fatalf("expected %s at position %d, got %s", want, i, result.path)
+		}
+	}
+}
+
+func TestFailureReportSortedIsASnapshot(t *testing.T) {
+	report := &failureReport{}
+	report.add(&resultRecord{path: "a.txt", err: errors.New("status 500")})
+
+	snapshot := report.sorted()
+	report.add(&resultRecord{path: "b.txt", err: errors.New("status 500")})
+
+	if len(snapshot) != 1 {
+		t.Fatalf("expected the snapshot to be unaffected, got %d results", len(snapshot))
+	}
+}

--- a/internal/commands/file/file_test.go
+++ b/internal/commands/file/file_test.go
@@ -3,7 +3,10 @@ package file
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
+
+	"github.com/uvasoftware/scanii-cli/internal/client"
 )
 
 // checkResponseContent checks that the result is the expected sample test file
@@ -112,6 +115,33 @@ func TestCallFileRetrieveEmptyID(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for empty id")
 	}
+}
+
+func TestAPIError(t *testing.T) {
+	message := "File is too large"
+	withRequestID := http.Header{requestIDHeader: {"req_abc123"}}
+
+	t.Run("prefers the api message", func(t *testing.T) {
+		err := apiError(413, withRequestID, &client.ErrorResponse{Error: &message})
+		if got, want := err.Error(), "status 413: File is too large (request id req_abc123)"; got != want {
+			t.Fatalf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("falls back to the status code", func(t *testing.T) {
+		err := apiError(500, http.Header{}, nil)
+		if got, want := err.Error(), "status 500"; got != want {
+			t.Fatalf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("tolerates an error response with no message", func(t *testing.T) {
+		empty := ""
+		err := apiError(502, withRequestID, &client.ErrorResponse{Error: &empty})
+		if got, want := err.Error(), "status 502 (request id req_abc123)"; got != want {
+			t.Fatalf("expected %q, got %q", want, got)
+		}
+	})
 }
 
 func TestExtractMetadata(t *testing.T) {

--- a/internal/commands/file/process.go
+++ b/internal/commands/file/process.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -149,8 +150,14 @@ func process(
 	}()
 
 	// a directory run only reports counts while it works, so the files that
-	// actually carry findings are collected and listed at the end
+	// actually carry findings — and the ones that could not be processed at all —
+	// are collected and listed at the end
 	findings := &findingsReport{}
+	failures := &failureReport{}
+
+	// results arrive from one goroutine per in-flight file, and a failure is
+	// reported in two writes — clearing the progress bar, then the message
+	var reportMu sync.Mutex
 
 	// Progress is measured in bytes handed to the transport rather than in files
 	// completed, so that a single large file — or a directory of a few of them —
@@ -171,8 +178,22 @@ func process(
 		onBytes:        tracker.addBytes,
 	}, func(result resultRecord) {
 		if result.err != nil {
-			slog.Error("failed to process file", "file", result.path, "error", result.err)
-			filesFailed.Add(1)
+			slog.Debug("failed to process file", "file", result.path, "error", result.err)
+			failed := filesFailed.Add(1)
+			failures.add(&result)
+
+			// a long directory run should not keep the first error to itself
+			// until the very end — but nor should it scroll the summary away
+			if isDirectory && failed <= maxFailuresShownLive {
+				reportMu.Lock()
+				terminal.ClearLine()
+				terminal.Error(fmt.Sprintf("%s — %s", result.path, result.err))
+				if failed == maxFailuresShownLive {
+					terminal.ClearLine()
+					terminal.Warn("further errors are suppressed, see the summary at the end of the run")
+				}
+				reportMu.Unlock()
+			}
 		} else {
 			filesFinished.Add(1)
 		}
@@ -209,9 +230,59 @@ func process(
 
 	fmt.Println()
 	terminal.Success(fmt.Sprintf("Completed in %s, %s file(s) analyzed. Throughput %s/s", terminal.FormatDuration(elapsed), terminal.FormatNumber(int64(filesFinished.Load())), terminal.FormatBytes(uint64(throughput)))) //nolint:gosec
-	terminal.Success(fmt.Sprintf("Files with findings: %d, unable to process: %d and successfully processed: %d", filesWithFindings.Load(), filesFailed.Load(), filesFinished.Load()))
 
-	return nil
+	counts := fmt.Sprintf("Files with findings: %d, unable to process: %d and successfully processed: %d", filesWithFindings.Load(), filesFailed.Load(), filesFinished.Load())
+	if filesFailed.Load() > 0 {
+		// a green checkmark next to "unable to process: 6" reads as success
+		terminal.Warn(counts)
+	} else {
+		terminal.Success(counts)
+	}
+
+	if filesFailed.Load() == 0 {
+		return nil
+	}
+
+	// a single file has already printed its own error above, and a directory run
+	// short enough to have reported every failure as it went does not need to
+	// repeat itself — the list is for the runs where they scrolled away
+	if isDirectory && filesFailed.Load() > maxFailuresShownLive {
+		printFailures(failures.sorted())
+	}
+
+	return fmt.Errorf("%d of %d file(s) could not be processed", filesFailed.Load(), filesTotal)
+}
+
+const (
+	// maxFailuresShownLive bounds how many failures are reported while a
+	// directory run is still going.
+	maxFailuresShownLive = 10
+
+	// maxFailuresListed bounds the end-of-run failure list. A directory where
+	// every file was rejected should not scroll the summary off the screen.
+	maxFailuresListed = 25
+)
+
+// printFailures lists the files a run could not process, with the reason for
+// each, so that they can be retried without re-reading the whole log.
+func printFailures(failed []resultRecord) {
+	if len(failed) == 0 {
+		return
+	}
+
+	fmt.Println()
+	terminal.Error(fmt.Sprintf("%s file(s) could not be processed:", terminal.FormatNumber(int64(len(failed))))) //nolint:gosec
+
+	listed := min(len(failed), maxFailuresListed)
+	items := make([]string, 0, listed)
+	for i := range failed[:listed] {
+		items = append(items, fmt.Sprintf("%s — %s", failed[i].path, failed[i].err))
+	}
+	terminal.ErrorList(items)
+
+	if remaining := len(failed) - listed; remaining > 0 {
+		terminal.Error(fmt.Sprintf("…and %s more", terminal.FormatNumber(int64(remaining)))) //nolint:gosec
+	}
 }
 
 // fsWalker calls handler for every file under root that is worth sending for

--- a/internal/commands/file/process.go
+++ b/internal/commands/file/process.go
@@ -136,6 +136,12 @@ func process(
 		bytesTotal += uint64(info.Size()) //nolint:gosec
 	}
 
+	// a walk that gives up part way through leaves files unvisited, which is a
+	// failure of the run rather than of any one file — counting it as a file
+	// would leave the count one ahead of the list of files that failed
+	var walkErr error
+	var walkMu sync.Mutex
+
 	fileChannel := make(chan string)
 	go func() {
 		_, err := fsWalker(path, ignoreHidden, func(filePath string, _ os.FileInfo) {
@@ -143,8 +149,10 @@ func process(
 			fileChannel <- filePath
 		})
 		if err != nil {
-			filesFailed.Add(1)
-			slog.Error("failed to walk directory", "error", err)
+			walkMu.Lock()
+			walkErr = err
+			walkMu.Unlock()
+			slog.Debug("failed to walk directory", "error", err)
 		}
 		close(fileChannel)
 	}()
@@ -239,7 +247,17 @@ func process(
 		terminal.Success(counts)
 	}
 
+	walkMu.Lock()
+	walked := walkErr
+	walkMu.Unlock()
+	if walked != nil {
+		terminal.Error(fmt.Sprintf("stopped reading %s, some files were never sent: %s", path, walked))
+	}
+
 	if filesFailed.Load() == 0 {
+		if walked != nil {
+			return fmt.Errorf("failed to read %s: %w", path, walked)
+		}
 		return nil
 	}
 

--- a/internal/commands/file/service.go
+++ b/internal/commands/file/service.go
@@ -95,7 +95,7 @@ func (s *service) process(ctx context.Context, stream chan string, opts processO
 
 			fd, err := os.Open(path)
 			if err != nil {
-				slog.Error("could not open file", "path", path, "error", err.Error())
+				slog.Debug("could not open file", "path", path, "error", err.Error())
 				r.err = err
 				consumer(r)
 				return nil
@@ -176,7 +176,7 @@ func (s *service) process(ctx context.Context, stream chan string, opts processO
 				if res.err == nil {
 					return false
 				}
-				slog.Error("could not build multipart payload", "path", path, "error", res.err.Error())
+				slog.Debug("could not build multipart payload", "path", path, "error", res.err.Error())
 				r.err = res.err
 				consumer(r)
 				return true
@@ -190,7 +190,7 @@ func (s *service) process(ctx context.Context, stream chan string, opts processO
 					if handleWriterError(writeRes) {
 						return nil
 					}
-					slog.Error("could not process file", "error", err.Error())
+					slog.Debug("could not process file", "path", path, "error", err.Error())
 					r.err = err
 					consumer(r)
 					return nil
@@ -202,8 +202,8 @@ func (s *service) process(ctx context.Context, stream chan string, opts processO
 				}
 
 				if result.StatusCode != http.StatusAccepted {
-					slog.Debug("error processing file", "path", path, "status", result.StatusCode)
-					r.err = fmt.Errorf("error processing file %s, status code %d", path, result.StatusCode)
+					r.err = apiError(result.StatusCode, result.Header, result.Error)
+					slog.Debug("api error processing file", "path", path, "status", result.StatusCode, "error", r.err.Error())
 				} else {
 					r.id = *result.Pending.ID
 					r.location = result.Header.Get("Location")
@@ -218,7 +218,7 @@ func (s *service) process(ctx context.Context, stream chan string, opts processO
 					if handleWriterError(writeRes) {
 						return nil
 					}
-					slog.Error("could not process file", "error", localErr.Error())
+					slog.Debug("could not process file", "path", path, "error", localErr.Error())
 					r.err = localErr
 					consumer(r)
 					return nil
@@ -235,8 +235,11 @@ func (s *service) process(ctx context.Context, stream chan string, opts processO
 				slog.Debug("response", "status", result.StatusCode)
 
 				if result.StatusCode != http.StatusCreated {
-					slog.Debug("error processing file", "path", path, "status", result.StatusCode)
-					r.err = fmt.Errorf("error processing file %s, status code %d", path, result.StatusCode)
+					// there is no result to check the checksum against, and the
+					// error the API returned is the one worth reporting
+					r.err = apiError(result.StatusCode, result.Header, result.Error)
+					slog.Debug("api error processing file", "path", path, "status", result.StatusCode, "error", r.err.Error())
+					slog.Debug("skipping checksum verification, the api returned an error", "path", path)
 				} else {
 					pr := result.Result
 					r.id = *pr.ID
@@ -259,10 +262,18 @@ func (s *service) process(ctx context.Context, stream chan string, opts processO
 						r.metadata = *pr.Metadata
 					}
 
-					if r.checksum != calculatedSha1 {
-						slog.Error("checksum mismatch", "expected", calculatedSha1, "actual", r.checksum)
-						r.err = fmt.Errorf("checksum mismatch, expected %s, actual %x", calculatedSha1, r.checksum)
-					} else {
+					// a comparison is only meaningful with both sides in hand —
+					// treating a missing checksum as a mismatch would fail a file
+					// the API accepted just fine
+					switch {
+					case r.checksum == "":
+						slog.Warn("no checksum in response, skipping verification", "path", path)
+					case calculatedSha1 == "":
+						slog.Warn("no locally calculated checksum, skipping verification", "path", path)
+					case r.checksum != calculatedSha1:
+						slog.Debug("checksum mismatch", "path", path, "expected", calculatedSha1, "actual", r.checksum)
+						r.err = fmt.Errorf("checksum mismatch, expected %s, actual %s", calculatedSha1, r.checksum)
+					default:
 						slog.Debug("checksum verified", "expected", calculatedSha1, "actual", r.checksum)
 					}
 				}

--- a/internal/commands/file/service_test.go
+++ b/internal/commands/file/service_test.go
@@ -3,9 +3,13 @@ package file
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/uvasoftware/scanii-cli/internal/commands/profile"
 )
 
 func newTestService(t *testing.T) *service {
@@ -144,6 +148,85 @@ func TestServiceProcessNonExistentFile(t *testing.T) {
 	if results[0].err == nil {
 		t.Fatalf("expected an error for non-existent file")
 	}
+}
+
+// newTestServiceWithBadCredentials returns a service pointed at the mock server
+// with credentials it will reject, which is the cheapest way to drive a real API
+// error response — status, body and request id included.
+func newTestServiceWithBadCredentials(t *testing.T) *service {
+	t.Helper()
+	svc, err := newService(&profile.Profile{
+		CreatedAt:   time.Now(),
+		Credentials: "bad:credentials",
+		Endpoint:    ts.Endpoint,
+	})
+	if err != nil {
+		t.Fatalf("failed to create service: %s", err)
+	}
+	return svc
+}
+
+func TestServiceProcessAPIError(t *testing.T) {
+	run := func(t *testing.T, async bool) resultRecord {
+		t.Helper()
+		svc := newTestServiceWithBadCredentials(t)
+
+		stream := make(chan string, 1)
+		stream <- fakeMalwareSample
+		close(stream)
+
+		var results []resultRecord
+		var mu sync.Mutex
+
+		err := svc.process(context.Background(), stream, processOptions{maxConcurrency: 1, async: async}, func(r resultRecord) {
+			mu.Lock()
+			results = append(results, r)
+			mu.Unlock()
+		})
+		if err != nil {
+			t.Fatalf("process failed: %s", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		return results[0]
+	}
+
+	t.Run("sync", func(t *testing.T) {
+		r := run(t, false)
+
+		if r.err == nil {
+			t.Fatal("expected an error for a rejected request")
+		}
+		// the API's own message, not just the status code
+		if !strings.Contains(r.err.Error(), "401") || !strings.Contains(r.err.Error(), "could not authenticate") {
+			t.Fatalf("expected the api error message, got %q", r.err)
+		}
+		if !strings.Contains(r.err.Error(), "request id ") {
+			t.Fatalf("expected the request id in the error, got %q", r.err)
+		}
+		// a rejected file has no checksum to verify against
+		if strings.Contains(r.err.Error(), "checksum") {
+			t.Fatalf("expected no checksum verification on an api error, got %q", r.err)
+		}
+		if r.checksum != "" || r.id != "" {
+			t.Fatalf("expected an empty result, got checksum %q and id %q", r.checksum, r.id)
+		}
+	})
+
+	t.Run("async", func(t *testing.T) {
+		r := run(t, true)
+
+		if r.err == nil {
+			t.Fatal("expected an error for a rejected request")
+		}
+		if !strings.Contains(r.err.Error(), "401") || !strings.Contains(r.err.Error(), "could not authenticate") {
+			t.Fatalf("expected the api error message, got %q", r.err)
+		}
+		if r.id != "" || r.location != "" {
+			t.Fatalf("expected an empty result, got id %q and location %q", r.id, r.location)
+		}
+	})
 }
 
 func TestServiceRetrieve(t *testing.T) {

--- a/internal/commands/server/routes.go
+++ b/internal/commands/server/routes.go
@@ -108,9 +108,11 @@ func Setup(mux *http.ServeMux, eng *engine.Engine, key, secret, data, baseURL st
 		})
 	}
 
-	// wrap wraps a handler func with the auth and headers middleware.
+	// wrap wraps a handler func with the auth and headers middleware. Headers go
+	// on the outside so that rejected requests carry a request id too — that id
+	// is the only handle a caller has on a failure.
 	wrap := func(h http.HandlerFunc) http.Handler {
-		return middleware(h, authMiddleware, headersMiddleware)
+		return middleware(h, headersMiddleware, authMiddleware)
 	}
 
 	// Static fixtures (unauthenticated) — used both by the CLI demo and

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -171,6 +171,24 @@ func List(items []string) {
 	}
 }
 
+// ClearLine erases the current line, so that a message can be printed over a
+// progress bar without leaving half a bar behind it. It is a no-op when output
+// is not a terminal, where there is no line to overwrite.
+func ClearLine() {
+	if !IsTTY() {
+		return
+	}
+	_, _ = fmt.Fprint(stdout, "\r\033[2K")
+}
+
+// ErrorList prints a numbered list of items to stderr, so that a list belonging
+// to an Error message stays on the same stream as its heading.
+func ErrorList(items []string) {
+	for i, item := range items {
+		_, _ = fmt.Fprintf(stderr, " %d. %s\n", i+1, item)
+	}
+}
+
 // Table prints an auto-aligned table with dim headers.
 func Table(headers []string, rows [][]string) {
 	cols := len(headers)

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -129,6 +129,16 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestErrorList(t *testing.T) {
+	out := captureErr(func() { ErrorList([]string{"a.txt — status 413", "b.txt — status 429"}) })
+	if !strings.Contains(out, "1. a.txt — status 413") {
+		t.Fatalf("expected first item, got %q", out)
+	}
+	if !strings.Contains(out, "2. b.txt — status 429") {
+		t.Fatalf("expected second item, got %q", out)
+	}
+}
+
 func TestTable(t *testing.T) {
 	out := captureOut(func() {
 		Table([]string{"NAME", "STATUS"}, [][]string{{"tok-1", "active"}, {"tok-2", "expired"}})


### PR DESCRIPTION
Closes #91.

## What

A file the API rejects (401, 413, 429, 5xx) used to surface as `error processing <path>, status code 401`, logged at **debug** level — invisible without `--verbose`. A directory run reported only `unable to process: 6`, never *which* six, and returned 0 either way, so a scan where every file was rejected looked much like a clean one.

## Changes

- **The API's own message is now read.** `ErrorResponse` was already parsed by the client and thrown away here; failures now read `status 413: File is too large (request id req_9f3a1c)`. The request id is what support needs to look the failure up.
- **Unprocessed files are tracked and reported.** The first ten are printed as they happen (a long run should not sit on its first error until the end); the full sorted list is printed at the end when more than that failed and the early ones scrolled away — capped at 25 with an `…and N more`. A short run does not repeat itself.
- **Non-zero exit when anything failed**, so a half-failed scan does not pass for a clean one in CI. Applies to `sc files process` and `sc files async`.
- **Checksum verification is only attempted when there is a checksum on both sides.** A `201` with no `checksum` field was being reported as a mismatch — failing a file the API had accepted. The mismatch message also formatted a hex string with `%x`.
- **Per-file failures log at debug and report through the terminal layer.** They previously went out as raw `slog.Error` lines, which in a non-verbose run are printed by Go's default handler and fight the progress bar for the same lines. The terminal now owns user-facing failure reporting; `-v` still gets the full structured detail.
- **Mock server:** the request id header is set outside the auth middleware, so rejected requests carry one too — matching the real API, where it comes from the edge.

## Output

Directory run, bad credentials:

```
Using endpoint: localhost:4321 and API key: key
Processing recursive directory sample with ~6 files | ~117 B
error: sample/file1.txt — status 401: Apologies but we could not authenticate this request. (request id req_A5JfC5Ako7JjFaz0)
...
Files 6/6 100% (117 B/117 B)

✔ Completed in 3 ms, 0 file(s) analyzed. Throughput 31 KB/s
warning: Files with findings: 0, unable to process: 6 and successfully processed: 0
error: 6 of 6 file(s) could not be processed
```

Exit code 1. With more than ten failures the same run adds the sorted list at the end.

## Tests

- `TestServiceProcessAPIError` (sync + async) drives a real 401 off the mock server with a bad-credentials profile: asserts the API's message, the status, the request id, an empty result and — explicitly — that no checksum error is produced.
- `TestAPIError` covers the formatter (API message, status-only fallback, empty message).
- `failures_test.go` mirrors the existing `findings_test.go` coverage, including concurrent adds.
- `TestErrorList` for the new stderr list helper.

`go test -race ./...` green, `golangci-lint run ./...` clean. Verified manually against the local mock server for: directory (small and >10 failures), single file, async, good credentials, and `-v`.

## Note

`sc files process` returning non-zero on partial failure is a behavior change for anyone scripting it. It seemed clearly right for CI use, but say the word and I'll drop it.


## Also on this branch

- An interrupted directory walk used to increment the failed-file counter, so `unable to process: N` could read one ahead of the list of files that actually failed. It is a failure of the run, not of a file — now reported on its own and returned as the command's error when no individual file failed.
- `ci: take the newest Go patch release in CI` — the audit job resolved `go-version: 1.26` to the runner image's 1.26.5, while govulncheck flags five stdlib advisories fixed in 1.26.6. `check-latest: true` picks up the patch release. Unrelated to this change but it was failing the branch.

## On the issue title

The issue is titled "causes processing to stop". I could not reproduce a stop: per-file errors return `nil` from their errgroup goroutine, so one rejected file has never aborted the run, and the local mock server does not model a size limit to test a real 413 against. What the issue describes as stopping may have been the run *appearing* to stop, since a rejected file produced no visible output at all. If you have a repro where the run genuinely halts on a 413, send it over — that would be a separate bug from this one.
